### PR TITLE
Check PHP Version and Presence of WooCommerce before Intitialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules/
 # whitelist
 !.gitignore
 !.editorconfig
+!.phpcs.xml
 wordpress/

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>The coding standard for PHP_CodeSniffer itself.</description>
+
+    <file>gebrueder-weiss-woocommerce.php</file>
+    <file>includes/</file>
+    <file>tests</file>
+
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg name="parallel" value="75"/>
+    <arg value="np"/>
+
+    <!-- Don't hide tokenizer exceptions -->
+    <rule ref="Internal.Tokenizer.Exception">
+        <type>error</type>
+    </rule>
+
+    <rule ref="PSR12">
+        <exclude name="PSR12.Files.FileHeader" />
+    </rule>
+    <rule ref="vendor/wp-coding-standards/wpcs/WordPress-Docs/ruleset.xml" />
+
+    <rule ref="PSR1.Methods.CamelCapsMethodName">
+        <exclude-pattern>/tests/*.php</exclude-pattern>
+    </rule>
+    
+
+
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "homepage": "https://www.towa-digital.com",
     "require-dev": {
         "phpunit/phpunit": "^7",
-        "squizlabs/php_codesniffer": "^3.6"
+        "squizlabs/php_codesniffer": "^3.6",
+        "wp-coding-standards/wpcs": "^2.3"
     },
     "license": "GPL-3.0-only",
     "authors": [
@@ -30,8 +31,8 @@
       }
     },
     "autoload-dev": {
-      "classmap": [
-        "tests/"
-      ]
+      "psr-4": {
+        "Tests\\" :"tests/"
+      }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7cfd4190f374c6c349f5d60479ccf5b6",
+    "content-hash": "c7eb49692ae1598a7710f45da56681f7",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -2056,6 +2056,57 @@
                 "validate"
             ],
             "time": "2021-03-09T10:59:23+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],
@@ -2065,5 +2116,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/gebrueder-weiss-woocommerce.php
+++ b/gebrueder-weiss-woocommerce.php
@@ -1,12 +1,10 @@
 <?php
-
 /**
  * Gebrüder Weiss Woocommere
  *
  * @package GbWeiss
- * @author towa-digital
- * @license GPL-3.0-or-later
- *
+ * @author Towa Digital <developer@towa.at>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html GPL-3.0-or-later
  *
  * @wordpress-plugin
  * Plugin Name: Gebrüder Weiss Woocommerce
@@ -29,6 +27,9 @@ if (!class_exists('GbWeiss', false)) {
     include_once dirname(__FILE__) . '/includes/GbWeiss.php';
 }
 
+/**
+ * Retrieve an instance of the plugin.
+ */
 function GbWeiss()
 {
     return GbWeiss\includes\GbWeiss::instance();
@@ -39,5 +40,5 @@ add_action("init", function () {
         return;
     };
 
-    // initialize the plugin here
+    // Initialize the plugin here.
 });

--- a/gebrueder-weiss-woocommerce.php
+++ b/gebrueder-weiss-woocommerce.php
@@ -33,3 +33,11 @@ function GbWeiss()
 {
     return GbWeiss\includes\GbWeiss::instance();
 }
+
+add_action("init", function () {
+    if (!GbWeiss\includes\GbWeiss::checkPluginCompatabilityAndPrintErrorMessages()) {
+        return;
+    };
+
+    // initialize the plugin here
+});

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -26,16 +26,64 @@ final class GbWeiss
         $this->init_hooks();
     }
 
-    public function init_hooks()
-    {
-
-    }
-
     public static function instance()
     {
         if (is_null(self::$instance) ) {
             self::$instance = new self();
         }
         return self::$instance;
+    }
+
+    public function init_hooks()
+    {
+
+    }
+
+    public static function checkPluginCompatabilityAndPrintErrorMessages(): bool
+    {
+        if (!self::pluginIsCompatibleWithCurrentPhpVersion()) {
+            $errorMessage = "Gebrüder Weiss WooCommerce is not compatible with PHP ".phpversion().".";
+            self::showWordpressAdminErrorMessage($errorMessage);
+            return false;
+        }
+
+        if (!self::isWooCommerceActive()) {
+            $errorMessage = "Gebrüder Weiss WooCommerce requires WooCommerce to be installed.";
+            self::showWordpressAdminErrorMessage($errorMessage);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function pluginIsCompatibleWithCurrentPhpVersion(): bool
+    {
+        if (PHP_MAJOR_VERSION === 8) {
+            return true;
+        }
+
+        if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION >= 2) {
+            return true;
+        }
+        return false;
+    }
+
+    private static function isWooCommerceActive(): bool
+    {
+        // as recommended by WooCommerce https://docs.woocommerce.com/document/create-a-plugin/
+        return in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')));
+    }
+
+    private static function showWordpressAdminErrorMessage(string $message): void
+    {
+        add_action(
+            "admin_notices", function () use ($message) {
+                ?>
+                    <div class="notice notice-error is-dismissible">
+                        <p><?php echo $message ?></p>
+                    </div>
+                <?php
+            }
+        );
     }
 }

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -1,7 +1,12 @@
 <?php
 /**
  * GbWeiss Setup
+ *
+ * @package GbWeiss
+ * @author Towa Digital <developer@towa.at>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html GPL-3.0-or-later
  */
+
 namespace GbWeiss\includes;
 
 defined('ABSPATH') || exit;
@@ -23,39 +28,56 @@ final class GbWeiss
      */
     public function __construct()
     {
-        $this->init_hooks();
+        $this->initHooks();
     }
 
-    public static function instance()
+    /**
+     * Returns the singleton instance for the GbWeiss class.
+     */
+    public static function instance(): GbWeiss
     {
-        if (is_null(self::$instance) ) {
+        if (is_null(self::$instance)) {
             self::$instance = new self();
         }
         return self::$instance;
     }
 
-    public function init_hooks()
+    /**
+     * Initializes the plugin
+     *
+     * @return void
+     */
+    public function initHooks(): void
     {
-
     }
 
+    /**
+     * Checks whether the plugin is compatible with the current
+     *  WordPress installation and shows error messages
+     * for compatibility issues in the admin panel.
+     */
     public static function checkPluginCompatabilityAndPrintErrorMessages(): bool
     {
         if (!self::pluginIsCompatibleWithCurrentPhpVersion()) {
-            $errorMessage = "Gebrüder Weiss WooCommerce is not compatible with PHP ".phpversion().".";
-            self::showWordpressAdminErrorMessage($errorMessage);
+            self::showWordpressAdminErrorMessage(
+                "Gebrüder Weiss WooCommerce is not compatible with PHP " . phpversion() . "."
+            );
             return false;
         }
 
         if (!self::isWooCommerceActive()) {
-            $errorMessage = "Gebrüder Weiss WooCommerce requires WooCommerce to be installed.";
-            self::showWordpressAdminErrorMessage($errorMessage);
+            self::showWordpressAdminErrorMessage(
+                "Gebrüder Weiss WooCommerce requires WooCommerce to be installed."
+            );
             return false;
         }
 
         return true;
     }
 
+    /**
+     * Checks if the plugin is compatible with the current PHP version.
+     */
     private static function pluginIsCompatibleWithCurrentPhpVersion(): bool
     {
         if (PHP_MAJOR_VERSION === 8) {
@@ -68,16 +90,32 @@ final class GbWeiss
         return false;
     }
 
+    /**
+     * Checks if the WooCommerce plugin is active.
+     */
     private static function isWooCommerceActive(): bool
     {
-        // as recommended by WooCommerce https://docs.woocommerce.com/document/create-a-plugin/
-        return in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')));
+        // As recommended by WooCommerce, see https://docs.woocommerce.com/document/create-a-plugin/ for reference.
+        return in_array(
+            'woocommerce/woocommerce.php',
+            apply_filters(
+                'active_plugins',
+                get_option('active_plugins')
+            )
+        );
     }
 
+
+    /**
+     * Shows the passed message as an error in the admin panel
+     *
+     * @param string $message The message to be shown in the admin panel.
+     */
     private static function showWordpressAdminErrorMessage(string $message): void
     {
         add_action(
-            "admin_notices", function () use ($message) {
+            "admin_notices",
+            function () use ($message) {
                 ?>
                     <div class="notice notice-error is-dismissible">
                         <p><?php echo $message ?></p>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,20 +5,20 @@
  * @package Gebrueder_Weiss_Woocommerce
  */
 
-if ( PHP_MAJOR_VERSION >= 8 ) {
-	echo "The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	exit( 1 );
+if (PHP_MAJOR_VERSION >= 8) {
+    echo "The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    exit(1);
 }
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
+$_tests_dir = getenv('WP_TESTS_DIR');
 
-if ( ! $_tests_dir ) {
-	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+if (! $_tests_dir) {
+    $_tests_dir = rtrim(sys_get_temp_dir(), '/\\') . '/wordpress-tests-lib';
 }
 
-if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
-	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	exit( 1 );
+if (! file_exists("{$_tests_dir}/includes/functions.php")) {
+    echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    exit(1);
 }
 
 // Give access to tests_add_filter() function.
@@ -26,12 +26,15 @@ require_once "{$_tests_dir}/includes/functions.php";
 
 /**
  * Manually load the plugin being tested.
+ *
+ * @return void
  */
-function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/gebrueder-weiss-woocommerce.php';
+function _manually_load_plugin(): void
+{
+    require dirname(dirname(__FILE__)) . '/gebrueder-weiss-woocommerce.php';
 }
 
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+tests_add_filter('muplugins_loaded', '_manually_load_plugin');
 
 // Start up the WP testing environment.
 require "{$_tests_dir}/includes/bootstrap.php";

--- a/tests/test-sample.php
+++ b/tests/test-sample.php
@@ -2,19 +2,25 @@
 /**
  * Class SampleTest
  *
- * @package Gebrueder_Weiss_Woocommerce
+ * @package GbWeiss
+ * @author Towa Digital <developer@towa.at>
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html GPL-3.0-or-later
  */
+
+ namespace Tests;
 
 /**
  * Sample test case.
  */
-class SampleTest extends WP_UnitTestCase {
+class SampleTest extends \WP_UnitTestCase
+{
 
-	/**
-	 * A single example test.
-	 */
-	public function test_sample() {
-		// Replace this with some actual testing code.
-		$this->assertTrue( true );
-	}
+    /**
+     * A single example test.
+     */
+    public function test_sample()
+    {
+        // Replace this with some actual testing code.
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
## TLDR;

- checks if the plugin is compatible with the currently used PHP version
  - if not compatible an error messag is shown in the backend and the initialization is aborted
  - if compatible the plugin initializes
- adds a phpcs configuration file which extends PSR12 and the WordPress Docs Style
  - updates the code to match this style