### PR TITLE
Add Github Workflow for Linting and Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: secret
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --default-authentication-plugin=mysql_native_password
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           MYSQL_PASSWORD: secret
           MYSQL_ROOT_PASSWORD: secret
         ports:
-          - 33306:3306
+          - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop, master ]
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+
+jobs:
+  linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: Install Composer Dependencies
+        run: composer install
+
+      - name: Execute PHPCS
+        run: vendor/bin/phpcs
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php_version: ["7.3", "7.4", "8.0"]
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_USER: user
+          MYSQL_PASSWORD: secret
+          MYSQL_ROOT_PASSWORD: secret
+        ports:
+          - 33306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php_version }}
+
+      - name: Install Composer Dependencies
+        run: composer install
+
+      - name: Setup Wordpress Test Database
+        run: bash ./bin/install-wp-tests.sh wordpress_test root secret mysql
+
+      - name: Execute PHPUnit
+        run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: composer install
 
       - name: Setup Wordpress Test Database
-        run: bash ./bin/install-wp-tests.sh wordpress_test root secret localhost
+        run: bash ./bin/install-wp-tests.sh wordpress_test root secret 127.0.0.1
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,14 @@ jobs:
         php_version: ["7.3", "7.4"]
     services:
       mysql:
-        image: mysql:8
+        image: mysql:5.7
         env:
           MYSQL_USER: user
           MYSQL_PASSWORD: secret
           MYSQL_ROOT_PASSWORD: secret
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --default-auth=mysql_native_password
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ["7.3", "7.4", "8.0"]
+        php_version: ["7.3", "7.4"]
     services:
       mysql:
         image: mysql:8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: composer install
 
       - name: Setup Wordpress Test Database
-        run: bash ./bin/install-wp-tests.sh wordpress_test root secret mysql
+        run: bash ./bin/install-wp-tests.sh wordpress_test root secret localhost
 
       - name: Execute PHPUnit
         run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: secret
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --default-authentication-plugin=mysql_native_password
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --default-auth=mysql_native_password
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules/
 !.editorconfig
 !.phpcs.xml
 !.husky/
+!.github/
 wordpress/


### PR DESCRIPTION
## TLDR;
- adds a GitHub Action for Linting and Testing
- action is exectued on develop, master and merge requests to develop
- linting is executed using php 7.4
- tests are executed for the php versions 7.3 and 7.4, php 8 is currently not supported by wordpress