### PR TITLE
Feature/wcwpp 69 allow validation from the plugin options

### DIFF
--- a/gebrueder-weiss-woocommerce.php
+++ b/gebrueder-weiss-woocommerce.php
@@ -46,8 +46,3 @@ add_action("init", function () {
     $plugin->setOrderStateRepository(new OrderStateRepository());
     $plugin->initialize();
 });
-
-add_action("admin_init", function () {
-    $plugin = GbWeiss::getInstance();
-    $plugin->showErrorMessageIfSelectedOrderStatesDoNotExist();
-});

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -135,7 +135,7 @@ final class GbWeiss extends Singleton
                 self::showWordpressAdminErrorMessage(__("Your credentials were not accepted by the Gebrüder Weiss API.", self::$languageDomain));
             }
         } catch (\Exception $e) {
-            self::showWordpressAdminErrorMessage(__("Sending an authentication request to the Gebrüder Weiss API Failed", self::$languageDomain));
+            self::showWordpressAdminErrorMessage(__("Sending an authentication request to the Gebrüder Weiss API Failed.", self::$languageDomain));
         }
     }
 

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -11,7 +11,6 @@ namespace GbWeiss\includes;
 
 use GbWeiss\includes\OrderStateRepository;
 use GbWeiss\includes\OAuth\OAuthAuthenticator;
-use GbWeiss\includes\OAuth\OAuthToken;
 
 defined('ABSPATH') || exit;
 

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -7,12 +7,12 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html GPL-3.0-or-later
  */
 
+defined('ABSPATH') || exit;
+
 namespace GbWeiss\includes;
 
 use GbWeiss\includes\OrderStateRepository;
 use GbWeiss\includes\OAuth\OAuthAuthenticator;
-
-defined('ABSPATH') || exit;
 
 /**
  * Main GbWeiss class

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -7,9 +7,9 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.en.html GPL-3.0-or-later
  */
 
-defined('ABSPATH') || exit;
-
 namespace GbWeiss\includes;
+
+defined('ABSPATH') || exit;
 
 use GbWeiss\includes\OrderStateRepository;
 use GbWeiss\includes\OAuth\OAuthAuthenticator;

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -114,6 +114,7 @@ final class GbWeiss extends Singleton
      */
     public function initActions(): void
     {
+        \add_action('admin_init', [$this, 'showErrorMessageIfSelectedOrderStatesDoNotExist']);
         \add_action('admin_menu', [$this, 'addPluginPageToMenu']);
     }
 
@@ -154,7 +155,7 @@ final class GbWeiss extends Singleton
 
         if (!self::isWooCommerceActive()) {
             self::showWordpressAdminErrorMessage(
-                __("Gebrüder Weiss WooCommerce requires WooCommerce to be installed.", self::$languageDomain)
+                __("Gebrüder Weiss WooCommerce requires WooCommerce to be installed and active.", self::$languageDomain)
             );
             return false;
         }

--- a/includes/Tab.php
+++ b/includes/Tab.php
@@ -61,6 +61,13 @@ class Tab implements CanRender
     public $page;
 
     /**
+     * Callbacks for onTabInit
+     *
+     * @var array
+     */
+    private $onTabInitCallbacks = [];
+
+    /**
      * Initialize Tab on Options Page
      *
      * @param string $name Name of the tab.
@@ -90,6 +97,7 @@ class Tab implements CanRender
     private function addActions()
     {
         \add_action('admin_init', [$this, 'addSettingsSection'], 10);
+        \add_action('admin_head', [$this, 'fireOnTabInitIfCurrentTab'], 10);
     }
 
     /**
@@ -131,6 +139,22 @@ class Tab implements CanRender
     }
 
     /**
+     * Fires the on tab init callbacks if the tab is to be shown
+     *
+     * @return void
+     */
+    public function fireOnTabInitIfCurrentTab(): void
+    {
+        if (!$this->isActive) {
+            return;
+        }
+
+        foreach ($this->onTabInitCallbacks as $callback) {
+            $callback();
+        }
+    }
+
+    /**
      * Renders Tab
      *
      * @return void
@@ -148,7 +172,15 @@ class Tab implements CanRender
      */
     public function onTabInit(callable $callbackFunction): Tab
     {
-        $callbackFunction();
+        /**
+         * When passing the function directly to the callback array
+         * PHP is not able to execute it later on. Wrapping it into
+         * an anonymous closure prevents that.
+         */
+        $this->onTabInitCallbacks[] = function () use ($callbackFunction) {
+            $callbackFunction();
+        };
+
         return $this;
     }
 }

--- a/tests/integration/test-plugin-initialization.php
+++ b/tests/integration/test-plugin-initialization.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests;
+
+use GbWeiss\includes\GbWeiss;
+
+class TestPluginInitialization extends \WP_UnitTestCase
+{
+    public function test_it_registers_an_init_hook()
+    {
+        global $wp_filter;
+        $numberOfInitFiltersBeforeRegistration = count($wp_filter['init'][10]);
+        include(dirname(__FILE__) . "/../../gebrueder-weiss-woocommerce.php");
+        $numberOfInitFiltersAfterRegistration = count($wp_filter['init'][10]);
+
+        $this->assertSame(1, $numberOfInitFiltersAfterRegistration - $numberOfInitFiltersBeforeRegistration);
+    }
+
+    public function test_it_adds_an_admin_notice_if_woocommerce_is_not_installed()
+    {
+        global $wp_filter;
+        $numberOfInitFiltersBeforeCheck = count($wp_filter['admin_notices'][10]);
+        GbWeiss::checkPluginCompatabilityAndPrintErrorMessages();
+        $numberOfInitFiltersAfterCheck = count($wp_filter['admin_notices'][10]);
+
+        $this->assertSame(1, $numberOfInitFiltersAfterCheck - $numberOfInitFiltersBeforeCheck);
+    }
+
+    public function test_it_does_not_pass_compatibility_check_without_woocommerce_active()
+    {
+        $this->assertFalse(GbWeiss::checkPluginCompatabilityAndPrintErrorMessages());
+    }
+
+    public function test_it_does_not_passes_the_compatibility_check_with_woocommerce_active()
+    {
+        update_option("active_plugins", ["woocommerce/woocommerce.php"]);
+        $this->assertTrue(GbWeiss::checkPluginCompatabilityAndPrintErrorMessages());
+    }
+}


### PR DESCRIPTION
## TLDR;

- fixes plugin activation if woocommerce is not active
- executes credentials validation only on the credentials tab