### PR TITLE
Feature/wcwpp 81 adapt fulfillment states settings validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 GEBRUEDER_WEISS_OAUTH_TOKEN_URL=https://oauth.gebrueder-weiss-woocommerce.towa-online.at/oauth/token
+GEBRUEDER_WEISS_API_URL=https://api.gebrueder-weiss-woocommerce.towa-online.at/

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
 
-if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+if [ $# -lt 3 ] && [ -z $WCPAY_DIR ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [wc-version] [skip-database-creation]"
 	exit 1
 fi
 
-DB_NAME=$1
-DB_USER=$2
-DB_PASS=$3
-DB_HOST=${4-localhost}
+DB_NAME=${1-wcpay_tests}
+DB_USER=${2-root}
+DB_PASS=${3-$MYSQL_ROOT_PASSWORD}
+DB_HOST=${4-$WORDPRESS_DB_HOST}
 WP_VERSION=${5-latest}
-SKIP_DB_CREATE=${6-false}
+WC_VERSION=${6-latest}
+SKIP_DB_CREATE=${7-false}
 
 TMPDIR=${TMPDIR-/tmp}
 TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
-WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 download() {
     if [ `which curl` ]; then
@@ -23,6 +24,56 @@ download() {
     elif [ `which wget` ]; then
         wget -nv -O "$2" "$1"
     fi
+}
+
+wp() {
+	WORKING_DIR="$PWD"
+	cd "$WP_CORE_DIR"
+
+	if [ ! -f $TMPDIR/wp-cli.phar ]; then
+		download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar  "$TMPDIR/wp-cli.phar"
+	fi
+	php "$TMPDIR/wp-cli.phar" $@
+
+	cd "$WORKING_DIR"
+}
+
+get_db_connection_flags() {
+	# parse DB_HOST for port or socket references
+	local DB_HOST_PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${DB_HOST_PARTS[0]};
+	local DB_SOCK_OR_PORT=${DB_HOST_PARTS[1]};
+	local EXTRA_FLAGS=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA_FLAGS=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA_FLAGS=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA_FLAGS=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+	echo "--user=$DB_USER --password=$DB_PASS $EXTRA_FLAGS";
+}
+
+wait_db() {
+	local MYSQLADMIN_FLAGS=$(get_db_connection_flags)
+	local WAITS=0
+
+	set +e
+	mysqladmin status $MYSQLADMIN_FLAGS > /dev/null
+	while [[ $? -ne 0 ]]; do
+		((WAITS++))
+		if [ $WAITS -ge 6 ]; then
+			echo "Maximum database wait time exceeded"
+			exit 1
+		fi;
+		echo "Waiting until the database is available..."
+		sleep 5s
+		mysqladmin status $MYSQLADMIN_FLAGS > /dev/null
+	done
+	set -e
 }
 
 if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
@@ -51,48 +102,28 @@ else
 	fi
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
-set -ex
+set -e
 
 install_wp() {
-
 	if [ -d $WP_CORE_DIR ]; then
 		return;
 	fi
 
 	mkdir -p $WP_CORE_DIR
 
-	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-		mkdir -p $TMPDIR/wordpress-trunk
-		rm -rf $TMPDIR/wordpress-trunk/*
-		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
-		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
-	else
-		if [ $WP_VERSION == 'latest' ]; then
-			local ARCHIVE_NAME='latest'
-		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
-			# https serves multiple offers, whereas http serves single.
-			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
-			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
-				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
-				LATEST_VERSION=${WP_VERSION%??}
-			else
-				# otherwise, scan the releases and get the most up to date minor version of the major release
-				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
-				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
-			fi
-			if [[ -z "$LATEST_VERSION" ]]; then
-				local ARCHIVE_NAME="wordpress-$WP_VERSION"
-			else
-				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
-			fi
-		else
-			local ARCHIVE_NAME="wordpress-$WP_VERSION"
-		fi
-		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
-		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
-	fi
+	wp core download --version=$WP_VERSION
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+configure_wp() {
+	WP_SITE_URL="http://local.wordpress.test"
+	wait_db
+
+	if [[ ! -f "$WP_CORE_DIR/wp-config.php" ]]; then
+		wp core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
+	fi
+	wp core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --skip-email
 }
 
 install_test_suite() {
@@ -107,9 +138,8 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		rm -rf $WP_TESTS_DIR/{includes,data}
-		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then
@@ -117,65 +147,70 @@ install_test_suite() {
 		# remove all forward slashes in the end
 		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
 	fi
-
-}
-
-recreate_db() {
-	shopt -s nocasematch
-	if [[ $1 =~ ^(y|yes)$ ]]
-	then
-		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
-		create_db
-		echo "Recreated the database ($DB_NAME)."
-	else
-		echo "Leaving the existing database ($DB_NAME) in place."
-	fi
-	shopt -u nocasematch
-}
-
-create_db() {
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 
 install_db() {
-
 	if [ ${SKIP_DB_CREATE} = "true" ]; then
 		return 0
 	fi
 
-	# parse DB_HOST for port or socket references
-	local PARTS=(${DB_HOST//\:/ })
-	local DB_HOSTNAME=${PARTS[0]};
-	local DB_SOCK_OR_PORT=${PARTS[1]};
-	local EXTRA=""
+	wait_db
+	local MYSQLADMIN_FLAGS=$(get_db_connection_flags)
 
-	if ! [ -z $DB_HOSTNAME ] ; then
-		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
-			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
-		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
-			EXTRA=" --socket=$DB_SOCK_OR_PORT"
-		elif ! [ -z $DB_HOSTNAME ] ; then
-			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
-		fi
-	fi
+	# drop database if exists
+	set +e
+	mysqladmin drop --force $DB_NAME $MYSQLADMIN_FLAGS &> /dev/null
+	set -e
 
 	# create database
-	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
-	then
-		echo "Reinstalling will delete the existing test database ($DB_NAME)"
-		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
-		recreate_db $DELETE_EXISTING_DB
+	mysqladmin create $DB_NAME $MYSQLADMIN_FLAGS
+}
+
+install_woocommerce() {
+	WC_INSTALL_EXTRA=''
+	INSTALLED_WC_VERSION=$(wp plugin get woocommerce --field=version)
+
+	if [[ $WC_VERSION == 'beta' ]]; then
+		# Get the latest non-trunk version number from the .org repo. This will usually be the latest release, beta, or rc.
+		WC_VERSION=$(curl https://api.wordpress.org/plugins/info/1.0/woocommerce.json | jq -r '.versions | with_entries(select(.key|match("beta";"i"))) | keys[-1]' --sort-keys)
+	fi
+
+	if [[ -n $INSTALLED_WC_VERSION ]] && [[ $WC_VERSION == 'latest' ]]; then
+		# WooCommerce is already installed, we just must update it to the latest stable version
+		wp plugin update woocommerce
+		wp plugin activate woocommerce
 	else
-		create_db
+		if [[ $INSTALLED_WC_VERSION != $WC_VERSION ]]; then
+			# WooCommerce is installed but it's the wrong version, overwrite the installed version
+			WC_INSTALL_EXTRA+=" --force"
+		fi
+		if [[ $WC_VERSION != 'latest' ]] && [[ $WC_VERSION != 'beta' ]]; then
+			WC_INSTALL_EXTRA+=" --version=$WC_VERSION"
+		fi
+		wp plugin install woocommerce --activate$WC_INSTALL_EXTRA
+	fi
+}
+
+install_gutenberg() {
+	INSTALLED_GUTENBERG_VERSION=$(wp plugin get gutenberg --field=version)
+
+	if [[ -n $INSTALLED_GUTENBERG_VERSION ]]; then
+		# Gutenberg is already installed, we just must update it to the latest stable version
+		wp plugin update gutenberg
+		wp plugin activate gutenberg
+	else
+		wp plugin install gutenberg --activate
 	fi
 }
 
 install_wp
-install_test_suite
 install_db
+configure_wp
+install_test_suite
+install_gutenberg
+install_woocommerce

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -196,21 +196,8 @@ install_woocommerce() {
 	fi
 }
 
-install_gutenberg() {
-	INSTALLED_GUTENBERG_VERSION=$(wp plugin get gutenberg --field=version)
-
-	if [[ -n $INSTALLED_GUTENBERG_VERSION ]]; then
-		# Gutenberg is already installed, we just must update it to the latest stable version
-		wp plugin update gutenberg
-		wp plugin activate gutenberg
-	else
-		wp plugin install gutenberg --activate
-	fi
-}
-
 install_wp
 install_db
 configure_wp
 install_test_suite
-install_gutenberg
 install_woocommerce

--- a/gebrueder-weiss-woocommerce.php
+++ b/gebrueder-weiss-woocommerce.php
@@ -27,6 +27,7 @@ use GbWeiss\includes\OAuth\OAuthAuthenticator;
 use GbWeiss\includes\OrderStateRepository;
 use GbWeiss\includes\SettingsRepository;
 use League\OAuth2\Client\Provider\GenericProvider;
+use Towa\GebruederWeissSDK\Api\WriteApi;
 
 /**
  * Use Dotenv to set required environment variables and load .env file in root
@@ -41,7 +42,7 @@ add_action("init", function () {
 
     $plugin = GbWeiss::getInstance();
 
-
+    $apiEndpoint = env('GEBRUEDER_WEISS_API_URL', 'https://apitest.gw-world.com:443/');
     $tokenEndpoint = env('GEBRUEDER_WEISS_OAUTH_TOKEN_URL', 'https://apitest.gw-world.com:443/token');
 
     $authProvider = new GenericProvider([
@@ -56,10 +57,13 @@ add_action("init", function () {
     ]);
     $authenticationClient = new OAuthAuthenticator($authProvider);
 
+    $writeApi = new WriteApi();
+    $writeApi->getConfig()->setHost($apiEndpoint);
 
     $plugin->setAuthenticationClient($authenticationClient);
     $plugin->setOrderStateRepository(new OrderStateRepository());
     $plugin->setSettingsRepository(new SettingsRepository());
+    $plugin->setWriteApiClient($writeApi);
     $plugin->initialize();
 });
 

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Factory for creating Logistics Orders
+ *
+ * @package GbWeiss
+ */
+
+namespace GbWeiss\includes;
+
+defined('ABSPATH') || exit;
+
+use Towa\GebruederWeissSDK\Model\LogisticsOrder;
+
+/**
+ * Factory for creating Logistics Orders
+ */
+class LogisticsOrderFactory
+{
+    /**
+     * Creates a logistics order from a WooCommerce order
+     *
+     * @param object $wooCommerceOrder The order to be converted into a logistics order.
+     * @return LogisticsOrder
+     */
+    public static function buildFromWooCommerceOrder(object $wooCommerceOrder): LogisticsOrder
+    {
+        return new LogisticsOrder();
+    }
+}

--- a/includes/OrderStateRepository.php
+++ b/includes/OrderStateRepository.php
@@ -7,6 +7,8 @@
 
 namespace GbWeiss\includes;
 
+defined('ABSPATH') || exit;
+
 /**
  * Repository for WooCommerce Order Statuses
  */

--- a/tests/Integration/TokenTest.php
+++ b/tests/Integration/TokenTest.php
@@ -7,15 +7,12 @@ use GbWeiss\includes\OAuth\OAuthAuthenticator;
 use GbWeiss\includes\OAuth\OAuthToken;
 use GbWeiss\includes\SettingsRepository;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
 
 class TokenTest extends \WP_UnitTestCase
 {
-    public function tearDown(): void
-    {
-        parent::tearDown();
-        Mockery::close();
-    }
+    use MockeryPHPUnitIntegration;
 
     /**
      * Test if an Access Token can be retrieved and stored in the options table.

--- a/tests/Unit/WooCommerceOrderStatusChangedTest.php
+++ b/tests/Unit/WooCommerceOrderStatusChangedTest.php
@@ -81,7 +81,7 @@ class WooCommerceOrderStatusChangedTest extends TestCase
         $order->allows("set_status");
         $order->allows("save");
 
-        $this->plugin->createLogisticsOrderAndUpdateOrderState($order);
+        $this->plugin->wooCommerceOrderStatusChanged(21, "from-state", self::SELECTED_FULFILLMENT_STATE, $order);
 
         $this->writeApi->shouldHaveReceived("logisticsOrderPost", [LogisticsOrder::class]);
     }

--- a/tests/Unit/WooCommerceOrderStatusChangedTest.php
+++ b/tests/Unit/WooCommerceOrderStatusChangedTest.php
@@ -116,23 +116,4 @@ class WooCommerceOrderStatusChangedTest extends TestCase
 
         $order->shouldNotHaveReceived("save");
     }
-
-    public function test_it_does_not_update_the_order_state_after_a_failed_network_request()
-    {
-        /** @var MockInterface|WriteApi */
-        $writeApi = Mockery::mock(WriteApi::class);
-        $writeApi->shouldReceive("logisticsOrderPost")->andThrow(new ApiException("Unauthenticated", 401));
-        $writeApi->allows(["getConfig" => new Configuration()]);
-
-        $this->plugin->setWriteApiClient($writeApi);
-
-        /** @var MockInterface|stdClass */
-        $order = Mockery::mock("WC_Order");
-        $order->allows("set_status");
-        $order->allows("save");
-
-        $this->plugin->createLogisticsOrderAndUpdateOrderState($order);
-
-        $order->shouldNotHaveReceived("save");
-    }
 }

--- a/tests/Unit/WooCommerceOrderStatusChangedTest.php
+++ b/tests/Unit/WooCommerceOrderStatusChangedTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Unit;
+
+use GbWeiss\includes\GbWeiss;
+use GbWeiss\includes\OAuth\OAuthAuthenticator;
+use GbWeiss\includes\OAuth\OAuthToken;
+use GbWeiss\includes\SettingsRepository;
+use PHPUnit\Framework\TestCase;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+use Towa\GebruederWeissSDK\Api\WriteApi;
+use Towa\GebruederWeissSDK\ApiException;
+use Towa\GebruederWeissSDK\Configuration;
+use Towa\GebruederWeissSDK\Model\LogisticsOrder;
+
+class WooCommerceOrderStatusChangedTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private const SELECTED_FULFILLMENT_STATE = "selected-state";
+    private const PREFIXED_SELECTED_FULFILLMENT_STATE = "wc-selected-state";
+
+    /** @var GbWeiss */
+    private $plugin;
+
+    /** @var MockInterface|WriteApi */
+    private $writeApi;
+
+    /** @var MockInterface|SettingsRepository */
+    private $settingsRepository;
+
+    /** @var MockInterface|OAuthAuthenticator */
+    private $authenticator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var GbWeiss */
+        $this->plugin = GbWeiss::getInstance();
+
+        /** @var MockInterface|WriteApi */
+        $this->writeApi = Mockery::mock(WriteApi::class);
+        $this->writeApi->allows("logisticsOrderPost");
+        $this->writeApi->allows(["getConfig" => new Configuration()]);
+
+        /** @var MockInterface|SettingsRepository */
+        $this->settingsRepository = Mockery::mock(SettingsRepository::class);
+        $this->settingsRepository->allows([
+            "getFulfillmentState" => self::PREFIXED_SELECTED_FULFILLMENT_STATE,
+            "getClientId" => "id",
+            "getClientSecret" => "secret",
+            "setAccessToken" => null,
+            "getAccessToken" => "token",
+        ]);
+
+        /** @var MockInterface|OAuthAuthenticator */
+        $this->authenticator = Mockery::mock(OAuthAuthenticator::class);
+        $this->authenticator->allows([
+            "authenticate" => new OAuthToken("token", "Bearer", 3600)
+        ]);
+
+        $this->plugin->setWriteApiClient($this->writeApi);
+        $this->plugin->setSettingsRepository($this->settingsRepository);
+        $this->plugin->setAuthenticationClient($this->authenticator);
+    }
+
+    public function test_it_does_not_call_the_api_if_fulfillment_state_does_not_match_the_selection()
+    {
+        $this->plugin->wooCommerceOrderStatusChanged(21, "from-state", "some-state", (object)[]);
+
+        $this->writeApi->shouldNotHaveBeenCalled(["logisticsOrderPost"]);
+    }
+
+    public function test_it_calls_the_api_if_the_fulfillment_state_matches_the_selection()
+    {
+        /** @var MockInterface|object */
+        $order = Mockery::mock("WC_Order");
+        $order->allows("set_status");
+        $order->allows("save");
+
+        $this->plugin->createLogisticsOrderAndUpdateOrderState($order);
+
+        $this->writeApi->shouldHaveReceived("logisticsOrderPost", [LogisticsOrder::class]);
+    }
+
+    public function test_it_updates_the_order_state_after_a_successful_api_request()
+    {
+        /** @var MockInterface|stdClass */
+        $order = Mockery::mock("WC_Order");
+        $order->allows("set_status");
+        $order->allows("save");
+
+        $this->plugin->createLogisticsOrderAndUpdateOrderState($order);
+
+        $order->shouldHaveReceived("save");
+    }
+
+    public function test_it_does_not_update_the_order_state_after_a_failed_request()
+    {
+        /** @var MockInterface|WriteApi */
+        $writeApi = Mockery::mock(WriteApi::class);
+        $writeApi->shouldReceive("logisticsOrderPost")->andThrow(new ApiException("Unauthenticated", 401));
+        $writeApi->allows(["getConfig" => new Configuration()]);
+
+        $this->plugin->setWriteApiClient($writeApi);
+
+        /** @var MockInterface|stdClass */
+        $order = Mockery::mock("WC_Order");
+        $order->allows("set_status");
+        $order->allows("save");
+
+        $this->plugin->createLogisticsOrderAndUpdateOrderState($order);
+
+        $order->shouldNotHaveReceived("save");
+    }
+
+    public function test_it_does_not_update_the_order_state_after_a_failed_network_request()
+    {
+        /** @var MockInterface|WriteApi */
+        $writeApi = Mockery::mock(WriteApi::class);
+        $writeApi->shouldReceive("logisticsOrderPost")->andThrow(new ApiException("Unauthenticated", 401));
+        $writeApi->allows(["getConfig" => new Configuration()]);
+
+        $this->plugin->setWriteApiClient($writeApi);
+
+        /** @var MockInterface|stdClass */
+        $order = Mockery::mock("WC_Order");
+        $order->allows("set_status");
+        $order->allows("save");
+
+        $this->plugin->createLogisticsOrderAndUpdateOrderState($order);
+
+        $order->shouldNotHaveReceived("save");
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,9 @@ require_once "{$_tests_dir}/includes/functions.php";
 function _manually_load_plugin(): void
 {
     require dirname(dirname(__FILE__)) . '/gebrueder-weiss-woocommerce.php';
+
+    // Load the WooCommerce plugin so we can use its classes in our WooCommerce Payments plugin.
+    require_once WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
 }
 
 tests_add_filter('muplugins_loaded', '_manually_load_plugin');


### PR DESCRIPTION
## TLDR

- updates the test setup script to install woocommerce as a plugin
- sends a fulfillment order request to the gbw api on the configured state transition

## Addidtional Info

Test Setup Script was copied from the [Automaticc Woocommerce Payments Plugin](https://github.com/Automattic/woocommerce-payments/blob/develop/bin/install-wp-tests.sh).

Creating a Logistics Order from a WooCommerce order is out of scope for this PR.