### PR TITLE
Feature/wcwpp 12/handling response

### DIFF
--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -75,7 +75,7 @@ final class GbWeiss extends Singleton
      */
     private $writeApiClient = null;
 
-    /** Order Controller to manipulate WooCommerce Orders.
+    /** Order Controller that provides the callback handling.
      *
      * @var OrderController;
      */

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -94,8 +94,6 @@ final class GbWeiss extends Singleton
         $this->orderController = new OrderController($this->settingsRepository);
     }
 
-
-
     /**
      * Initializes the option page.
      *

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -75,6 +75,12 @@ final class GbWeiss extends Singleton
      */
     private $writeApiClient = null;
 
+    /** Order Controller to manipulate WooCommerce Orders.
+     *
+     * @var OrderController;
+     */
+     private $orderController = null;
+
     /**
      * Initializes the plugin.
      *
@@ -85,7 +91,10 @@ final class GbWeiss extends Singleton
         $this->initActions();
         $this->initOptionPage();
         $this->registerUninstallHook();
+        $this->orderController = new OrderController($this->settingsRepository);
     }
+
+
 
     /**
      * Initializes the option page.

--- a/includes/OrderController.php
+++ b/includes/OrderController.php
@@ -2,7 +2,7 @@
 /**
  * Order Controller
  *
- * Used to manipulate WooCommerce Orders.
+ * Used to provide a callback used by the Gebrueder Weiss API.
  *
  * @package GbWeiss
  */

--- a/includes/OrderController.php
+++ b/includes/OrderController.php
@@ -38,7 +38,7 @@ class OrderController
         \add_action('rest_api_init', function () {
             register_rest_route(self::NAMESPACE, '/update/(?P<id>\d+)', array(
                 'methods' => 'POST',
-                'callback' => array($this, 'handleCallback')
+                'callback' => [$this, 'handleOrderUpdateRequest']
             ));
         });
     }
@@ -48,7 +48,7 @@ class OrderController
      *
      * @param \WP_REST_Request $request the post request.
      */
-    public function handleCallback(\WP_REST_Request $request): WP_REST_Response
+    public function handleOrderUpdateRequest(\WP_REST_Request $request): WP_REST_Response
     {
         $id = $request->get_params()['id'];
         try {

--- a/includes/OrderController.php
+++ b/includes/OrderController.php
@@ -18,7 +18,7 @@ defined('ABSPATH') || exit;
  */
 class OrderController
 {
-    private const NAMESPACE = 'gebrueder-weiss-woocommerce';
+    private const NAMESPACE = 'gebrueder-weiss-woocommerce/v1';
 
     /**
      * The settings used by the OrderController instance.
@@ -51,13 +51,15 @@ class OrderController
      */
     public function handleCallback(\WP_REST_Request $request): WP_REST_Response
     {
+        $id = $request->get_params()['id'];
         try {
-            $id = $request->get_params()['id'];
-            $order = new \WC_order($id);
-            $this->updateOrderStatus($order, $this->settings->getFulfilledState());
+            $order = new \WC_Order($id);
         } catch (\Exception $e) {
             return new \WP_REST_Response(null, 404, null);
         }
+
+        $this->updateOrderStatus($order, $this->settings->getFulfilledState());
+
         return new WP_REST_Response(null, 200, null);
     }
 
@@ -68,7 +70,7 @@ class OrderController
      * @param string    $status the new order status.
      * @return void
      */
-    private function updateOrderStatus(\WC_Order $order, string $status)
+    public function updateOrderStatus(\WC_Order $order, string $status)
     {
         $order->set_status($status);
         $order->save();

--- a/includes/OrderController.php
+++ b/includes/OrderController.php
@@ -2,7 +2,7 @@
 /**
  * Order Controller
  *
- * Used to provide a callback used by the Gebrueder Weiss API.
+ * Used to provide the callback endpoint & handling.
  *
  * @package GbWeiss
  */
@@ -26,7 +26,6 @@ class OrderController
      * @var SettingsRepository
      */
     private $settings = null;
-
 
     /**
      * Constructor.
@@ -59,7 +58,6 @@ class OrderController
         }
 
         $this->updateOrderStatus($order, $this->settings->getFulfilledState());
-
         return new WP_REST_Response(null, 200, null);
     }
 

--- a/includes/OrderController.php
+++ b/includes/OrderController.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Order Controller
+ *
+ * Used to manipulate WooCommerce Orders.
+ *
+ * @package GbWeiss
+ */
+
+namespace GbWeiss\includes;
+
+use WP_REST_Response;
+
+defined('ABSPATH') || exit;
+
+/**
+ * OptionsPage Class
+ */
+class OrderController
+{
+    private const NAMESPACE = 'gebrueder-weiss-woocommerce';
+
+    /**
+     * The settings used by the OrderController instance.
+     *
+     * @var SettingsRepository
+     */
+    private $settings = null;
+
+
+    /**
+     * Constructor.
+     *
+     * @param SettingsRepository $settings the states.
+     */
+    public function __construct(SettingsRepository $settings)
+    {
+        $this->settings = $settings;
+        \add_action('rest_api_init', function () {
+            register_rest_route(self::NAMESPACE, '/update/(?P<id>\d+)', array(
+                'methods' => 'POST',
+                'callback' => array($this, 'handleCallback')
+            ));
+        });
+    }
+
+    /**
+     * The callback handler.
+     *
+     * @param \WP_REST_Request $request the post request.
+     */
+    public function handleCallback(\WP_REST_Request $request): WP_REST_Response
+    {
+        try {
+            $id = $request->get_params()['id'];
+            $order = new \WC_order($id);
+            $this->updateOrderStatus($order, $this->settings->getFulfilledState());
+        } catch (\Exception $e) {
+            return new \WP_REST_Response(null, 404, null);
+        }
+        return new WP_REST_Response(null, 200, null);
+    }
+
+    /**
+     * Sets the new WooCommerce Order Status.
+     *
+     * @param \WC_Order $order the woo commerce order.
+     * @param string    $status the new order status.
+     * @return void
+     */
+    private function updateOrderStatus(\WC_Order $order, string $status)
+    {
+        $order->set_status($status);
+        $order->save();
+    }
+}

--- a/tests/Integration/FulfillmentRequestTest.php
+++ b/tests/Integration/FulfillmentRequestTest.php
@@ -25,7 +25,9 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
         $order->allows("save");
 
         $controller = new OrderController($settingsRepository);
+
         $controller->updateOrderStatus($order, 'wc-fulfilled');
+
         $order->shouldHaveReceived('set_status', ['wc-fulfilled']);
         $order->shouldHaveReceived('save');
     }

--- a/tests/Integration/FulfillmentRequestTest.php
+++ b/tests/Integration/FulfillmentRequestTest.php
@@ -26,7 +26,9 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
 
         $controller = new OrderController($settingsRepository);
 
+
         $controller->updateOrderStatus($order, 'wc-fulfilled');
+
 
         $order->shouldHaveReceived('set_status', ['wc-fulfilled']);
         $order->shouldHaveReceived('save');
@@ -44,7 +46,9 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
 
         $controller = new OrderController($settingsRepository);
 
+
         $response = $controller->handleOrderUpdateRequest($request);
+
 
         $this->assertEquals(404, $response->status);
     }
@@ -62,7 +66,11 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
         $request->allows('get_params')->andReturn(['id' => $order->get_id()]);
 
         $controller = new OrderController($settingsRepository);
+
+
         $response = $controller->handleOrderUpdateRequest($request);
+
+
         $this->assertEquals(200, $response->status);
     }
 }

--- a/tests/Integration/FulfillmentRequestTest.php
+++ b/tests/Integration/FulfillmentRequestTest.php
@@ -8,7 +8,6 @@ use Mockery;
 use Mockery\MockInterface;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
-
 class FulfillmentRequestTest extends \WP_UnitTestCase
 {
     use MockeryPHPUnitIntegration;
@@ -17,9 +16,7 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
     {
         /** @var SettingsRepository|MockInterface */
         $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows([
-          'getFulfilledState' => 'wc-fulfilled'
-        ]);
+        $settingsRepository->allows(['getFulfilledState' => 'wc-fulfilled']);
 
         /** @var MockInterface|WC_Order */
         $order = Mockery::mock("WC_Order");
@@ -52,9 +49,7 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
     {
         /** @var SettingsRepository|MockInterface */
         $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows([
-          'getFulfilledState' => 'wc-fulfilled'
-        ]);
+        $settingsRepository->allows(['getFulfilledState' => 'wc-fulfilled']);
 
         $order = wc_create_order();
 

--- a/tests/Integration/FulfillmentRequestTest.php
+++ b/tests/Integration/FulfillmentRequestTest.php
@@ -30,7 +30,7 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
         $order->shouldHaveReceived('save');
     }
 
-    public function test_it_returns_on_callback_with_404()
+    public function test_it_returns_a_404_response_if_no_order_with_the_given_id_exists()
     {
         /** @var SettingsRepository|MockInterface */
         $settingsRepository = Mockery::mock(SettingsRepository::class);
@@ -41,7 +41,9 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
         $request->allows('get_params')->andReturn(['id' => 12]);
 
         $controller = new OrderController($settingsRepository);
-        $response = $controller->handleCallback($request);
+
+        $response = $controller->handleOrderUpdateRequest($request);
+
         $this->assertEquals(404, $response->status);
     }
 
@@ -58,7 +60,7 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
         $request->allows('get_params')->andReturn(['id' => $order->get_id()]);
 
         $controller = new OrderController($settingsRepository);
-        $response = $controller->handleCallback($request);
+        $response = $controller->handleOrderUpdateRequest($request);
         $this->assertEquals(200, $response->status);
     }
 }

--- a/tests/Integration/FulfillmentRequestTest.php
+++ b/tests/Integration/FulfillmentRequestTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Integration;
+
+use GbWeiss\includes\OrderController;
+use GbWeiss\includes\SettingsRepository;
+use Mockery;
+use Mockery\MockInterface;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+
+class FulfillmentRequestTest extends \WP_UnitTestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function test_it_does_update_the_woocommerce_order_status()
+    {
+        /** @var SettingsRepository|MockInterface */
+        $settingsRepository = Mockery::mock(SettingsRepository::class);
+        $settingsRepository->allows([
+          'getFulfilledState' => 'wc-fulfilled'
+        ]);
+
+        /** @var MockInterface|WC_Order */
+        $order = Mockery::mock("WC_Order");
+        $order->allows("set_status");
+        $order->allows("get_status");
+        $order->allows("save");
+
+        $controller = new OrderController($settingsRepository);
+        $controller->updateOrderStatus($order, 'wc-fulfilled');
+        $order->shouldHaveReceived('set_status', ['wc-fulfilled']);
+        $order->shouldHaveReceived('save');
+    }
+
+    public function test_it_returns_on_callback_with_404()
+    {
+        /** @var SettingsRepository|MockInterface */
+        $settingsRepository = Mockery::mock(SettingsRepository::class);
+        $settingsRepository->allows();
+
+        /** @var \WP_REST_Request|MockInterface */
+        $request = Mockery::mock(\WP_REST_Request::class);
+        $request->allows('get_params')->andReturn(['id' => 12]);
+
+        $controller = new OrderController($settingsRepository);
+        $response = $controller->handleCallback($request);
+        $this->assertEquals(404, $response->status);
+    }
+
+    public function test_it_returns_on_callback_with_200()
+    {
+        /** @var SettingsRepository|MockInterface */
+        $settingsRepository = Mockery::mock(SettingsRepository::class);
+        $settingsRepository->allows([
+          'getFulfilledState' => 'wc-fulfilled'
+        ]);
+
+        $order = wc_create_order();
+
+        /** @var \WP_REST_Request|MockInterface */
+        $request = Mockery::mock(\WP_REST_Request::class);
+        $request->allows('get_params')->andReturn(['id' => $order->get_id()]);
+
+        $controller = new OrderController($settingsRepository);
+        $response = $controller->handleCallback($request);
+        $this->assertEquals(200, $response->status);
+    }
+}

--- a/tests/Integration/FulfillmentRequestTest.php
+++ b/tests/Integration/FulfillmentRequestTest.php
@@ -53,7 +53,7 @@ class FulfillmentRequestTest extends \WP_UnitTestCase
         $this->assertEquals(404, $response->status);
     }
 
-    public function test_it_returns_on_callback_with_200()
+    public function test_it_returns_a_200_response_if_a_order_with_the_given_id_exists()
     {
         /** @var SettingsRepository|MockInterface */
         $settingsRepository = Mockery::mock(SettingsRepository::class);


### PR DESCRIPTION
TLDR:

- added OrderController
- provides endpoint for the callback
- provides handling of a mocked successful response due to lack of knowledge of the structure of the gebrueder weiß api callback request
-  updated woo commerce order status by provided id and setting of the settings repository
- added tests 
