### PR TITLE
Feature/wcwpp 78 prepare logistics order

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 GEBRUEDER_WEISS_OAUTH_TOKEN_URL=https://oauth.gebrueder-weiss-woocommerce.towa-online.at/oauth/token
-GEBRUEDER_WEISS_API_URL=https://api.gebrueder-weiss-woocommerce.towa-online.at/
+GEBRUEDER_WEISS_API_URL=https://api.gebrueder-weiss-woocommerce.towa-online.at

--- a/gebrueder-weiss-woocommerce.php
+++ b/gebrueder-weiss-woocommerce.php
@@ -23,6 +23,7 @@ defined('ABSPATH') || exit;
 require __DIR__ . '/vendor/autoload.php';
 
 use GbWeiss\includes\GbWeiss;
+use GbWeiss\includes\LogisticsOrderFactory;
 use GbWeiss\includes\OAuth\OAuthAuthenticator;
 use GbWeiss\includes\OrderStateRepository;
 use GbWeiss\includes\SettingsRepository;
@@ -60,10 +61,14 @@ add_action("init", function () {
     $writeApi = new WriteApi();
     $writeApi->getConfig()->setHost($apiEndpoint);
 
+    $settingsRepository = new SettingsRepository();
+    $logisticsOrderFactory = new LogisticsOrderFactory($settingsRepository);
+
     $plugin->setAuthenticationClient($authenticationClient);
     $plugin->setOrderStateRepository(new OrderStateRepository());
-    $plugin->setSettingsRepository(new SettingsRepository());
+    $plugin->setSettingsRepository($settingsRepository);
     $plugin->setWriteApiClient($writeApi);
+    $plugin->setLogisticsOrderFactory($logisticsOrderFactory);
     $plugin->initialize();
 });
 

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -76,6 +76,13 @@ final class GbWeiss extends Singleton
     private $writeApiClient = null;
 
     /**
+     * Factory for building logistics orders.
+     *
+     * @var LogisticsOrderFactory
+     */
+    private $logisticsOrderFactory = null;
+
+    /**
      * Initializes the plugin.
      *
      * @return void
@@ -251,7 +258,7 @@ final class GbWeiss extends Singleton
      */
     public function createLogisticsOrderAndUpdateOrderState(object $order)
     {
-        $logisticsOrder = LogisticsOrderFactory::buildFromWooCommerceOrder($order);
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($order);
         $authToken = $this->settingsRepository->getAccessToken();
         $this->writeApiClient->getConfig()->setAccessToken($authToken);
 
@@ -388,6 +395,17 @@ final class GbWeiss extends Singleton
     public function setWriteApiClient(WriteApi $client): void
     {
         $this->writeApiClient = $client;
+    }
+
+    /**
+     * Sets the factory for creating logistics orders.
+     *
+     * @param LogisticsOrderFactory LogisticsOrderFactory $logisticsOrderFactory The factory.
+     * @return void
+     */
+    public function setLogisticsOrderFactory(LogisticsOrderFactory $logisticsOrderFactory): void
+    {
+        $this->logisticsOrderFactory = $logisticsOrderFactory;
     }
 
     /**

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -105,7 +105,7 @@ final class GbWeiss extends Singleton
         $accountTab = (new Tab(__('Account', self::$languageDomain), 'account'))->onTabInit([$this, 'validateCredentials']);
 
         $accountTab
-            ->addOption(new Option('Customer Id', 'customer_id', __('Customer Id', self::$languageDomain), 'account', 'integer'))
+            ->addOption(new Option('Customer Id', 'customer_id', __('Customer Id', self::$languageDomain), 'account', 'string'))
             ->addOption(new Option('Client Id', 'client_id', __('Client Id', self::$languageDomain), 'account', 'string'))
             ->addOption(new Option('Client Secret', 'client_secret', __('Client Secret', self::$languageDomain), 'account', 'string'));
         $optionsPage->addTab($accountTab);

--- a/includes/GbWeiss.php
+++ b/includes/GbWeiss.php
@@ -105,7 +105,7 @@ final class GbWeiss extends Singleton
         $accountTab = (new Tab(__('Account', self::$languageDomain), 'account'))->onTabInit([$this, 'validateCredentials']);
 
         $accountTab
-            ->addOption(new Option('Customer Id', 'customer_id', __('Customer Id', self::$languageDomain), 'account', 'string'))
+            ->addOption(new Option('Customer Id', 'customer_id', __('Customer Id', self::$languageDomain), 'account', 'integer'))
             ->addOption(new Option('Client Id', 'client_id', __('Client Id', self::$languageDomain), 'account', 'string'))
             ->addOption(new Option('Client Secret', 'client_secret', __('Client Secret', self::$languageDomain), 'account', 'string'));
         $optionsPage->addTab($accountTab);

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -56,7 +56,7 @@ class LogisticsOrderFactory
 
         $logisticsOrder->setLogisticsAddresses([
             $this->createConsigneeAddress($wooCommerceOrder),
-            $this->createOrderByAddress()
+            $this->createOrderbyAddress()
         ]);
 
         $logisticsOrder->setOrderLines(
@@ -95,18 +95,18 @@ class LogisticsOrderFactory
         $contact->setName($fullName);
         $contact->setEmail($wooCommerceOrder->get_billing_email());
         $contact->setPhone($wooCommerceOrder->get_billing_phone());
-        $contact->setLanguage("de-De");
+        $contact->setLanguage("de-DE");
         $logisticsAddress->setContact($contact);
 
         return $logisticsAddress;
     }
 
     /**
-     * Creates the order by address from
+     * Creates the order by address
      *
      * @return LogisticsAddress
      */
-    private function createOrderByAddress(): LogisticsAddress
+    private function createOrderbyAddress(): LogisticsAddress
     {
         $logisticsAddress = new LogisticsAddress();
         $logisticsAddress->setAddressType("orderby");

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -114,6 +114,7 @@ class LogisticsOrderFactory
         $addressReference = new AddressReference();
         $addressReference->setQualifier("gwcustomerid");
         $addressReference->setReference($this->settingsRepository->getCustomerId());
+        $logisticsAddress->setAddressReferences([$addressReference]);
 
         return $logisticsAddress;
     }

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -9,7 +9,16 @@ namespace GbWeiss\includes;
 
 defined('ABSPATH') || exit;
 
+use Towa\GebruederWeissSDK\Model\Address;
+use Towa\GebruederWeissSDK\Model\AddressReference;
+use Towa\GebruederWeissSDK\Model\Article;
+use Towa\GebruederWeissSDK\Model\ArticleNote;
+use Towa\GebruederWeissSDK\Model\Contact;
+use Towa\GebruederWeissSDK\Model\LingualText;
+use Towa\GebruederWeissSDK\Model\LogisticsAddress;
 use Towa\GebruederWeissSDK\Model\LogisticsOrder;
+use Towa\GebruederWeissSDK\Model\LogisticsRequirements;
+use Towa\GebruederWeissSDK\Model\OrderLine;
 
 /**
  * Factory for creating Logistics Orders
@@ -17,13 +26,134 @@ use Towa\GebruederWeissSDK\Model\LogisticsOrder;
 class LogisticsOrderFactory
 {
     /**
+     * Settings Repository
+     *
+     * @var SettingsRepository
+     */
+    private $settingsRepository;
+
+    /**
+     * Creates an instance of the logistics order factory
+     *
+     * @param SettingsRepository $settingsRepository An instance of the settings repository.
+     */
+    public function __construct(SettingsRepository $settingsRepository)
+    {
+        $this->settingsRepository = $settingsRepository;
+    }
+
+    /**
      * Creates a logistics order from a WooCommerce order
      *
      * @param object $wooCommerceOrder The order to be converted into a logistics order.
      * @return LogisticsOrder
      */
-    public static function buildFromWooCommerceOrder(object $wooCommerceOrder): LogisticsOrder
+    public function buildFromWooCommerceOrder(object $wooCommerceOrder): LogisticsOrder
     {
-        return new LogisticsOrder();
+        $logisticsOrder = new LogisticsOrder();
+        $logisticsOrder->setUrl($this->settingsRepository->getSiteUrl() . "/wp-json/gebrueder-weiss-woocommerce/v1/update/" . $wooCommerceOrder->get_id());
+        $logisticsOrder->setCreationDateTime($wooCommerceOrder->get_date_created());
+
+        $logisticsOrder->setLogisticsAddresses([
+            $this->createConsigneeAddress($wooCommerceOrder),
+            $this->createOrderByAddress()
+        ]);
+
+        $logisticsOrder->setOrderLines(
+            $this->createOrderLines($wooCommerceOrder)
+        );
+
+        return $logisticsOrder;
+    }
+
+    /**
+     * Creates the consignee address from a WooCommerce Order.
+     *
+     * @param object $wooCommerceOrder The WooCommerce order.
+     * @return LogisticsAddress
+     */
+    private function createConsigneeAddress(object $wooCommerceOrder): LogisticsAddress
+    {
+        $logisticsAddress = new LogisticsAddress();
+        $logisticsAddress->setAddressType("consignee");
+
+        $address = new Address();
+        $address->setName1($wooCommerceOrder->get_shipping_first_name());
+        $address->setName2($wooCommerceOrder->get_shipping_last_name());
+        $address->setName3($wooCommerceOrder->get_shipping_company());
+        $address->setStreet1($wooCommerceOrder->get_shipping_address_1());
+        $address->setStreet2($wooCommerceOrder->get_shipping_address_2());
+        $address->setCity($wooCommerceOrder->get_shipping_city());
+        $address->setZipCode($wooCommerceOrder->get_shipping_postcode());
+        $address->setCountryCode($wooCommerceOrder->get_shipping_country());
+        $address->setState($wooCommerceOrder->get_shipping_state());
+        $logisticsAddress->setAddress($address);
+
+        $fullName = implode(" ", array_filter([$wooCommerceOrder->get_shipping_first_name(), $wooCommerceOrder->get_shipping_last_name()]));
+
+        $contact = new Contact();
+        $contact->setName($fullName);
+        $contact->setEmail($wooCommerceOrder->get_billing_email());
+        $contact->setPhone($wooCommerceOrder->get_billing_phone());
+        $contact->setLanguage("de-De");
+        $logisticsAddress->setContact($contact);
+
+        return $logisticsAddress;
+    }
+
+    /**
+     * Creates the order by address from
+     *
+     * @return LogisticsAddress
+     */
+    private function createOrderByAddress(): LogisticsAddress
+    {
+        $logisticsAddress = new LogisticsAddress();
+        $logisticsAddress->setAddressType("orderby");
+
+        $addressReference = new AddressReference();
+        $addressReference->setQualifier("gwcustomerid");
+        $addressReference->setReference($this->settingsRepository->getCustomerId());
+
+        return $logisticsAddress;
+    }
+
+    /**
+     * Creates order lines based on a WooCommerce order.
+     *
+     * @param object $wooCommerceOrder The WooCommerce order.
+     * @return array
+     */
+    private function createOrderLines(object $wooCommerceOrder): array
+    {
+        return array_map(function (object $orderItem) use ($wooCommerceOrder) {
+            $orderLine = new OrderLine();
+
+            $article = new Article();
+            $article->setLineItemNumber($orderItem->get_id());
+            $article->setArticleId(intval($orderItem->get_product()->get_sku()));
+            $article->setQuantity($orderItem->get_quantity());
+
+            $customerNote = new LingualText();
+            $customerNote->setLanguage("de-DE");
+            $customerNote->setText($wooCommerceOrder->get_customer_note());
+            $logisticsRequirementNote = new ArticleNote();
+            $logisticsRequirementNote->setNoteType("deliverynotearticle");
+            $logisticsRequirementNote->setNoteText($customerNote);
+
+            $logisticsRequirement = new LogisticsRequirements();
+            $logisticsRequirement->setNotes([$logisticsRequirementNote]);
+
+            $article->setLogisticsrequirement($logisticsRequirement);
+
+            $orderLine->setArticles([$article]);
+
+            return $orderLine;
+
+        /**
+         * We need to remove the keys from the items array since they are not in order.
+         * Not removing them will cause PHP to serialize the array as an object.
+         */
+        }, array_values($wooCommerceOrder->get_items("line_item")));
     }
 }

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -53,6 +53,7 @@ class LogisticsOrderFactory
         $logisticsOrder = new LogisticsOrder();
         $logisticsOrder->setUrl($this->settingsRepository->getSiteUrl() . "/wp-json/gebrueder-weiss-woocommerce/v1/update/" . $wooCommerceOrder->get_id());
         $logisticsOrder->setCreationDateTime($wooCommerceOrder->get_date_created());
+        $logisticsOrder->setOwnerId($this->settingsRepository->getCustomerId());
 
         $logisticsOrder->setLogisticsAddresses([
             $this->createConsigneeAddress($wooCommerceOrder),
@@ -113,7 +114,7 @@ class LogisticsOrderFactory
 
         $addressReference = new AddressReference();
         $addressReference->setQualifier("gwcustomerid");
-        $addressReference->setReference($this->settingsRepository->getCustomerId());
+        $addressReference->setReference(strval($this->settingsRepository->getCustomerId()));
         $logisticsAddress->setAddressReferences([$addressReference]);
 
         return $logisticsAddress;

--- a/includes/SettingsRepository.php
+++ b/includes/SettingsRepository.php
@@ -94,7 +94,7 @@ class SettingsRepository
      *
      * @return integer|null
      */
-    public function getCustomerId(): ?string
+    public function getCustomerId(): ?int
     {
         return $this->getOption("customer_id");
     }

--- a/includes/SettingsRepository.php
+++ b/includes/SettingsRepository.php
@@ -90,12 +90,32 @@ class SettingsRepository
     }
 
     /**
+     * Reads the customer id from the plugin settings.
+     *
+     * @return integer|null
+     */
+    public function getCustomerId(): ?int
+    {
+        return $this->getOption("customer_id");
+    }
+
+    /**
+     * Reads the wordpress site URL from the options.
+     *
+     * @return string|null
+     */
+    public function getSiteUrl(): ?string
+    {
+        return \get_site_url();
+    }
+
+    /**
      * Reads the plugin option with the passed name from the wordpress options
      *
      * @param string $name The name of the option.
-     * @return string|null
+     * @return mixed
      */
-    private function getOption(string $name): ?string
+    private function getOption(string $name)
     {
         return \get_option(Option::OPTIONS_PREFIX . $name, null);
     }

--- a/includes/SettingsRepository.php
+++ b/includes/SettingsRepository.php
@@ -94,7 +94,7 @@ class SettingsRepository
      *
      * @return integer|null
      */
-    public function getCustomerId(): ?int
+    public function getCustomerId(): ?string
     {
         return $this->getOption("customer_id");
     }

--- a/tests/Integration/SettingsRepositoryTest.php
+++ b/tests/Integration/SettingsRepositoryTest.php
@@ -82,10 +82,10 @@ class SettingsRepositoryTest extends \WP_UnitTestCase
 
     public function test_it_can_retrieve_the_customer_id()
     {
-        update_option("gbw_customer_id", "42");
+        update_option("gbw_customer_id", 42);
 
         $settingsRepository = new SettingsRepository();
 
-        $this->assertSame("42", $settingsRepository->getCustomerId());
+        $this->assertSame(42, $settingsRepository->getCustomerId());
     }
 }

--- a/tests/Integration/SettingsRepositoryTest.php
+++ b/tests/Integration/SettingsRepositoryTest.php
@@ -69,4 +69,23 @@ class SettingsRepositoryTest extends \WP_UnitTestCase
 
         $this->assertSame($token, get_option("gbw_accessToken"));
     }
+
+    public function test_it_can_retrieve_the_site_url()
+    {
+        $settingsRepository = new SettingsRepository();
+
+        $siteUrl = "http://test.com";
+        update_option('siteurl', $siteUrl);
+
+        $this->assertSame($siteUrl, $settingsRepository->getSiteUrl());
+    }
+
+    public function test_it_can_retrieve_the_customer_id()
+    {
+        update_option("gbw_customer_id", 42);
+
+        $settingsRepository = new SettingsRepository();
+
+        $this->assertSame(42, $settingsRepository->getCustomerId());
+    }
 }

--- a/tests/Integration/SettingsRepositoryTest.php
+++ b/tests/Integration/SettingsRepositoryTest.php
@@ -82,10 +82,10 @@ class SettingsRepositoryTest extends \WP_UnitTestCase
 
     public function test_it_can_retrieve_the_customer_id()
     {
-        update_option("gbw_customer_id", 42);
+        update_option("gbw_customer_id", "42");
 
         $settingsRepository = new SettingsRepository();
 
-        $this->assertSame(42, $settingsRepository->getCustomerId());
+        $this->assertSame("42", $settingsRepository->getCustomerId());
     }
 }

--- a/tests/Unit/LogisticsOrderFactoryTest.php
+++ b/tests/Unit/LogisticsOrderFactoryTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Tests\Unit;
+
+use DateTimeInterface;
+use GbWeiss\includes\LogisticsOrderFactory;
+use GbWeiss\includes\SettingsRepository;
+use PHPUnit\Framework\TestCase;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+
+class LogisticsOrderFactoryTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @var MockInterface|SettingsRepository */
+    private $settingsRepository;
+
+    /** @var LogisticsOrderFactory */
+    private $logisticsOrderFactory;
+
+    /** @var array */
+    private $wooCommerceOrderMockMethods;
+
+    /** @var array */
+    private $wooCommerceMockOrderItems;
+
+    public function setUp(): void
+    {
+        /** @var MockInterface|SettingsRepository */
+        $this->settingsRepository = Mockery::mock(SettingsRepository::class);
+        $this->settingsRepository->allows([
+            "getSiteUrl" => "http://test.com",
+            "getCustomerId" => 42,
+        ]);
+
+        $this->logisticsOrderFactory = new LogisticsOrderFactory($this->settingsRepository);
+
+        /** @var MockInterface|stdClass */
+        $product = Mockery::mock("WC_Product");
+        $product->allows([
+            "get_sku" => "234",
+        ]);
+
+        $orderItemMethods = [
+            "get_id" => 123,
+            "get_product" => $product,
+            "get_quantity" => 4,
+        ];
+
+        /** @var MockInterface|stdClass */
+        $orderItem1 = Mockery::mock("WC_Order");
+        $orderItem1->allows($orderItemMethods);
+
+        /** @var MockInterface|stdClass */
+        $orderItem2 = Mockery::mock("WC_Order");
+        $orderItem2->allows($orderItemMethods);
+
+        // WooCommerce returns the order items as array<string, WC_Order_Item>
+        $this->wooCommerceMockOrderItems = [
+            "1" => $orderItem1,
+            "3" => $orderItem2
+        ];
+
+        $this->wooCommerceOrderMockMethods = [
+            "get_id" => 12,
+            "get_date_created" => new \WC_DateTime("2021-07-29T14:53:52+00:00"),
+            "get_shipping_first_name" => "first-name",
+            "get_shipping_last_name" => "last-name",
+            "get_shipping_company" => "company",
+            "get_shipping_address_1" => "address-1",
+            "get_shipping_address_2" => "address-2",
+            "get_shipping_city" => "city",
+            "get_shipping_postcode" => "zip-code",
+            "get_shipping_country" => "country",
+            "get_shipping_state" => "state",
+            "get_billing_email" => "test@company.com",
+            "get_billing_phone" => "123456789",
+            "get_items" => $this->wooCommerceMockOrderItems,
+            "get_customer_note" => "note",
+        ];
+    }
+
+    public function test_it_adds_the_callback_url_to_the_logistics_order()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $this->assertSame("http://test.com/wp-json/gebrueder-weiss-woocommerce/v1/update/12", $logisticsOrder->getUrl());
+    }
+
+    public function test_it_adds_the_created_date_to_the_logistics_order()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $this->assertSame("2021-07-29T14:53:52+00:00", $logisticsOrder->getCreationDateTime()->format(DateTimeInterface::RFC3339));
+    }
+
+    public function test_it_correctly_adds_the_consignee_address()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $logisticsOrder->getLogisticsAddresses();
+        $address = $logisticsOrder->getLogisticsAddresses()[0];
+
+        $this->assertSame("consignee", $address->getAddressType());
+        $this->assertSame("first-name", $address->getAddress()->getName1());
+        $this->assertSame("last-name", $address->getAddress()->getName2());
+        $this->assertSame("company", $address->getAddress()->getName3());
+        $this->assertSame("address-1", $address->getAddress()->getStreet1());
+        $this->assertSame("address-2", $address->getAddress()->getStreet2());
+        $this->assertSame("city", $address->getAddress()->getCity());
+        $this->assertSame("zip-code", $address->getAddress()->getZipCode());
+        $this->assertSame("country", $address->getAddress()->getCountryCode());
+        $this->assertSame("state", $address->getAddress()->getState());
+    }
+
+    public function test_it_correctly_adds_the_consignee_contact()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $logisticsOrder->getLogisticsAddresses();
+        $address = $logisticsOrder->getLogisticsAddresses()[0];
+
+        $this->assertSame("first-name last-name", $address->getContact()->getName());
+        $this->assertSame("test@company.com", $address->getContact()->getEmail());
+        $this->assertSame("123456789", $address->getContact()->getPhone());
+    }
+
+    public function test_it_correctly_creates_the_consignee_contact_name_if_only_one_name_is_available()
+    {
+        $orderMethods = $this->wooCommerceOrderMockMethods;
+        $orderMethods["get_shipping_first_name"] = null;
+
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder($orderMethods));
+
+        $logisticsOrder->getLogisticsAddresses();
+        $address = $logisticsOrder->getLogisticsAddresses()[0];
+
+        $this->assertSame("last-name", $address->getContact()->getName());
+    }
+
+    public function test_it_correctly_adds_the_orderby_address()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $logisticsOrder->getLogisticsAddresses();
+        $address = $logisticsOrder->getLogisticsAddresses()[1];
+
+        $this->assertSame("orderby", $address->getAddressType());
+    }
+
+    public function test_it_builds_an_order_line_for_each_article()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $this->assertCount(2, $logisticsOrder->getOrderLines());
+    }
+
+    public function test_it_ensures_that_the_order_line_array_has_proper_keys()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $this->assertArrayHasKey(0, $logisticsOrder->getOrderLines());
+        $this->assertArrayHasKey(1, $logisticsOrder->getOrderLines());
+    }
+
+    public function test_it_adds_one_item_per_orderline()
+    {
+        $order = $this->createMockOrder();
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($order);
+
+        $order->shouldHaveReceived("get_items", ["line_item"]);
+        $this->assertCount(1, $logisticsOrder->getOrderLines()[0]->getArticles());
+    }
+
+    public function test_it_converts_woocommerce_order_items_into_articles()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $article = $logisticsOrder->getOrderLines()[0]->getArticles()[0];
+
+        $this->assertSame(234, $article->getArticleId());
+        $this->assertSame(123, $article->getLineItemNumber());
+        $this->assertSame(4, $article->getQuantity());
+    }
+
+    public function test_it_adds_one_delivery_note_to_the_article()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $article = $logisticsOrder->getOrderLines()[0]->getArticles()[0];
+
+        $this->assertCount(1, $article->getLogisticsrequirement()->getNotes());
+        $this->assertSame("deliverynotearticle", $article->getLogisticsrequirement()->getNotes()[0]->getNoteType());
+    }
+
+    public function test_it_adds_the_customer_message_to_the_delivery_note()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $article = $logisticsOrder->getOrderLines()[0]->getArticles()[0];
+
+        $this->assertSame("de-DE", $article->getLogisticsrequirement()->getNotes()[0]->getNoteText()->getLanguage());
+        $this->assertSame("note", $article->getLogisticsrequirement()->getNotes()[0]->getNoteText()->getText());
+    }
+
+    private function createMockOrder(?array $mockMethods = null)
+    {
+        /** @var MockInterface|stdClass */
+        $order = Mockery::mock("WC_Order");
+        $order->allows($mockMethods ?? $this->wooCommerceOrderMockMethods);
+
+        return $order;
+    }
+}

--- a/tests/Unit/LogisticsOrderFactoryTest.php
+++ b/tests/Unit/LogisticsOrderFactoryTest.php
@@ -150,6 +150,26 @@ class LogisticsOrderFactoryTest extends TestCase
         $this->assertSame("orderby", $address->getAddressType());
     }
 
+    public function test_it_adds_the_correct_qualifier_to_the_orderby_address()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $logisticsOrder->getLogisticsAddresses();
+        $address = $logisticsOrder->getLogisticsAddresses()[1];
+
+        $this->assertSame(42, $address->getAddressReferences()[0]->getReference());
+    }
+
+    public function test_it_adds_the_custom_id_to_the_orderby_address()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $logisticsOrder->getLogisticsAddresses();
+        $address = $logisticsOrder->getLogisticsAddresses()[1];
+
+        $this->assertSame("gwcustomerid", $address->getAddressReferences()[0]->getQualifier());
+    }
+
     public function test_it_builds_an_order_line_for_each_article()
     {
         $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());

--- a/tests/Unit/LogisticsOrderFactoryTest.php
+++ b/tests/Unit/LogisticsOrderFactoryTest.php
@@ -32,7 +32,7 @@ class LogisticsOrderFactoryTest extends TestCase
         $this->settingsRepository = Mockery::mock(SettingsRepository::class);
         $this->settingsRepository->allows([
             "getSiteUrl" => "http://test.com",
-            "getCustomerId" => 42,
+            "getCustomerId" => "42",
         ]);
 
         $this->logisticsOrderFactory = new LogisticsOrderFactory($this->settingsRepository);
@@ -157,7 +157,7 @@ class LogisticsOrderFactoryTest extends TestCase
         $logisticsOrder->getLogisticsAddresses();
         $address = $logisticsOrder->getLogisticsAddresses()[1];
 
-        $this->assertSame(42, $address->getAddressReferences()[0]->getReference());
+        $this->assertSame("42", $address->getAddressReferences()[0]->getReference());
     }
 
     public function test_it_adds_the_custom_id_to_the_orderby_address()

--- a/tests/Unit/LogisticsOrderFactoryTest.php
+++ b/tests/Unit/LogisticsOrderFactoryTest.php
@@ -32,7 +32,7 @@ class LogisticsOrderFactoryTest extends TestCase
         $this->settingsRepository = Mockery::mock(SettingsRepository::class);
         $this->settingsRepository->allows([
             "getSiteUrl" => "http://test.com",
-            "getCustomerId" => "42",
+            "getCustomerId" => 420000,
         ]);
 
         $this->logisticsOrderFactory = new LogisticsOrderFactory($this->settingsRepository);
@@ -50,11 +50,11 @@ class LogisticsOrderFactoryTest extends TestCase
         ];
 
         /** @var MockInterface|stdClass */
-        $orderItem1 = Mockery::mock("WC_Order");
+        $orderItem1 = Mockery::mock("WC_Order_Item_Product");
         $orderItem1->allows($orderItemMethods);
 
         /** @var MockInterface|stdClass */
-        $orderItem2 = Mockery::mock("WC_Order");
+        $orderItem2 = Mockery::mock("WC_Order_Item_Product");
         $orderItem2->allows($orderItemMethods);
 
         // WooCommerce returns the order items as array<string, WC_Order_Item>
@@ -94,6 +94,13 @@ class LogisticsOrderFactoryTest extends TestCase
         $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
 
         $this->assertSame("2021-07-29T14:53:52+00:00", $logisticsOrder->getCreationDateTime()->format(DateTimeInterface::RFC3339));
+    }
+
+    public function test_it_adds_the_owner_id_to_the_logistics_order()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $this->assertSame(420000, $logisticsOrder->getOwnerId());
     }
 
     public function test_it_correctly_adds_the_consignee_address()
@@ -157,7 +164,7 @@ class LogisticsOrderFactoryTest extends TestCase
         $logisticsOrder->getLogisticsAddresses();
         $address = $logisticsOrder->getLogisticsAddresses()[1];
 
-        $this->assertSame("42", $address->getAddressReferences()[0]->getReference());
+        $this->assertSame("420000", $address->getAddressReferences()[0]->getReference());
     }
 
     public function test_it_adds_the_custom_id_to_the_orderby_address()

--- a/tests/Unit/WooCommerceOrderStatusChangedTest.php
+++ b/tests/Unit/WooCommerceOrderStatusChangedTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use GbWeiss\includes\GbWeiss;
+use GbWeiss\includes\LogisticsOrderFactory;
 use GbWeiss\includes\OAuth\OAuthAuthenticator;
 use GbWeiss\includes\OAuth\OAuthToken;
 use GbWeiss\includes\SettingsRepository;
@@ -34,6 +35,9 @@ class WooCommerceOrderStatusChangedTest extends TestCase
     /** @var MockInterface|OAuthAuthenticator */
     private $authenticator;
 
+    /** @var MockInterface|LogisticsOrderFactory */
+    private $logisticsOrderFactory;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -54,6 +58,13 @@ class WooCommerceOrderStatusChangedTest extends TestCase
             "getClientSecret" => "secret",
             "setAccessToken" => null,
             "getAccessToken" => "token",
+            "getSiteUrl" => "http://test.com",
+        ]);
+
+        /** @var MockInterface|LogisticsOrderFactory */
+        $this->logisticsOrderFactory = Mockery::mock(LogisticsOrderFactory::class);
+        $this->logisticsOrderFactory->allows([
+            "buildFromWooCommerceOrder" => new LogisticsOrder(),
         ]);
 
         /** @var MockInterface|OAuthAuthenticator */
@@ -65,6 +76,7 @@ class WooCommerceOrderStatusChangedTest extends TestCase
         $this->plugin->setWriteApiClient($this->writeApi);
         $this->plugin->setSettingsRepository($this->settingsRepository);
         $this->plugin->setAuthenticationClient($this->authenticator);
+        $this->plugin->setLogisticsOrderFactory($this->logisticsOrderFactory);
     }
 
     public function test_it_does_not_call_the_api_if_fulfillment_state_does_not_match_the_selection()


### PR DESCRIPTION
## TLDR;

- Creates a logistics order for Gebüder Weiss from an WooCommerce Order
- Changes the customer id setting to a string, since it is required as a string in the API schema

## Additional Info

Please also validate that the mapping between the to objects has been implemented correctly.
You can find the documentation for the mapping  in [our Confluence](https://confluence.towa-digital.com/pages/viewpage.action?pageId=73372176). The documentation is a file at the bottom named `WooCommerce - OrderMapping.xlsx `. The relevant table in the Excel sheet is `LO Order Json Mapping`. Feel free to contact me if you have trouble finding it.

