### PR TITLE
Feature/wcwpp 13 store order information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "twig/twig": "^3.3",
         "guzzlehttp/guzzle": "^6",
-        "towa/gbw-sdk": "^1.0",
+        "towa/gbw-sdk": "^1.2.0",
         "vlucas/phpdotenv": "^5.3",
         "league/oauth2-client": "^2.6"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,35 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2070a438116313c0263b2a486bd43364",
+    "content-hash": "58bb165a5f26bb2cdab6f77123247e50",
     "packages": [
         {
             "name": "graham-campbell/result-type",
-            "version": "v1.0.1",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb"
+                "reference": "84afea85c6841deeea872f36249a206e878a5de0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/7e279d2cd5d7fbb156ce46daada972355cea27bb",
-                "reference": "7e279d2cd5d7fbb156ce46daada972355cea27bb",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/84afea85c6841deeea872f36249a206e878a5de0",
+                "reference": "84afea85c6841deeea872f36249a206e878a5de0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0|^8.0",
-                "phpoption/phpoption": "^1.7.3"
+                "php": "^7.0 || ^8.0",
+                "phpoption/phpoption": "^1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5|^7.5|^8.5|^9.0"
+                "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5.19 || ^9.5.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "GrahamCampbell\\ResultType\\": "src/"
@@ -45,7 +40,7 @@
             "authors": [
                 {
                     "name": "Graham Campbell",
-                    "email": "graham@alt-three.com"
+                    "email": "hello@gjcampbell.co.uk"
                 }
             ],
             "description": "An Implementation Of The Result Type",
@@ -58,7 +53,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.0.1"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.0.2"
             },
             "funding": [
                 {
@@ -70,7 +65,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-04-13T13:17:36+00:00"
+            "time": "2021-08-28T21:34:50+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -395,29 +390,29 @@
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.7.5",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "994ecccd8f3283ecf5ac33254543eb0ac946d525"
+                "reference": "5455cb38aed4523f99977c4a12ef19da4bfe2a28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/994ecccd8f3283ecf5ac33254543eb0ac946d525",
-                "reference": "994ecccd8f3283ecf5ac33254543eb0ac946d525",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/5455cb38aed4523f99977c4a12ef19da4bfe2a28",
+                "reference": "5455cb38aed4523f99977c4a12ef19da4bfe2a28",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9 || ^7.0 || ^8.0"
+                "php": "^7.0 || ^8.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4.1",
-                "phpunit/phpunit": "^4.8.35 || ^5.7.27 || ^6.5.6 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^6.5.14 || ^7.0.20 || ^8.5.19 || ^9.5.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -436,7 +431,7 @@
                 },
                 {
                     "name": "Graham Campbell",
-                    "email": "graham@alt-three.com"
+                    "email": "hello@gjcampbell.co.uk"
                 }
             ],
             "description": "Option Type for PHP",
@@ -448,7 +443,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.7.5"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.8.0"
             },
             "funding": [
                 {
@@ -460,7 +455,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-20T17:29:33+00:00"
+            "time": "2021-08-28T21:27:29+00:00"
         },
         {
             "name": "psr/http-message",
@@ -811,16 +806,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
                 "shasum": ""
             },
             "require": {
@@ -871,7 +866,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -887,7 +882,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:27:20+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
@@ -967,16 +962,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
                 "shasum": ""
             },
             "require": {
@@ -1030,7 +1025,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -1046,20 +1041,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-07-28T13:41:28+00:00"
         },
         {
             "name": "towa/gbw-sdk",
-            "version": "v1.0.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/towa-digital/gebrueder-weiss-php-client.git",
-                "reference": "65ecd6807f4f0b6c4433ef9bc37b274751d715ef"
+                "reference": "995146d3bbb25f87c962bdb57cbc026774822787"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/towa-digital/gebrueder-weiss-php-client/zipball/65ecd6807f4f0b6c4433ef9bc37b274751d715ef",
-                "reference": "65ecd6807f4f0b6c4433ef9bc37b274751d715ef",
+                "url": "https://api.github.com/repos/towa-digital/gebrueder-weiss-php-client/zipball/995146d3bbb25f87c962bdb57cbc026774822787",
+                "reference": "995146d3bbb25f87c962bdb57cbc026774822787",
                 "shasum": ""
             },
             "require": {
@@ -1067,7 +1062,7 @@
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "guzzlehttp/guzzle": "^6.2",
-                "php": ">=7.2"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.12",
@@ -1090,7 +1085,6 @@
                 }
             ],
             "description": "API to create and retrieve logistics orders",
-            "homepage": "https://app.swaggerhub.com/apis/martinWelte/logistics-order/1.0.0",
             "keywords": [
                 "api",
                 "openapi",
@@ -1102,9 +1096,9 @@
             ],
             "support": {
                 "issues": "https://github.com/towa-digital/gebrueder-weiss-php-client/issues",
-                "source": "https://github.com/towa-digital/gebrueder-weiss-php-client/tree/v1.0.0"
+                "source": "https://github.com/towa-digital/gebrueder-weiss-php-client/tree/v1.2.0"
             },
-            "time": "2021-07-14T09:15:05+00:00"
+            "time": "2021-09-06T12:02:41+00:00"
         },
         {
             "name": "twig/twig",
@@ -2079,16 +2073,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
                 "shasum": ""
             },
             "require": {
@@ -2126,7 +2120,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
             },
             "funding": [
                 {
@@ -2135,7 +2129,7 @@
                 }
             ],
             "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2021-07-26T12:15:06+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -2840,6 +2834,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -2947,16 +2942,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -2985,7 +2980,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -2993,7 +2988,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/gebrueder-weiss-woocommerce.php
+++ b/gebrueder-weiss-woocommerce.php
@@ -28,7 +28,7 @@ use Towa\GebruederWeissWooCommerce\OAuth\OAuthAuthenticator;
 use Towa\GebruederWeissWooCommerce\OrderStateRepository;
 use Towa\GebruederWeissWooCommerce\SettingsRepository;
 use League\OAuth2\Client\Provider\GenericProvider;
-use Towa\GebruederWeissSDK\Api\WriteApi;
+use Towa\GebruederWeissSDK\Api\DefaultApi;
 use Towa\GebruederWeissWooCommerce\FailedRequestQueue\FailedRequestRepository;
 use Towa\GebruederWeissWooCommerce\OrderRepository;
 
@@ -59,8 +59,8 @@ add_action("init", function () {
         'urlResourceOwnerDetails' => null
     ]);
 
-    $writeApi = new WriteApi();
-    $writeApi->getConfig()->setHost($apiEndpoint);
+    $gebruederWeissApi = new DefaultApi();
+    $gebruederWeissApi->getConfig()->setHost($apiEndpoint);
 
     $settingsRepository = new SettingsRepository();
     $logisticsOrderFactory = new LogisticsOrderFactory($settingsRepository);
@@ -69,7 +69,7 @@ add_action("init", function () {
     $plugin->setAuthenticationClient($authenticationClient);
     $plugin->setOrderStateRepository(new OrderStateRepository());
     $plugin->setSettingsRepository($settingsRepository);
-    $plugin->setWriteApiClient($writeApi);
+    $plugin->setGebruederWeissApiClient($gebruederWeissApi);
     $plugin->setLogisticsOrderFactory($logisticsOrderFactory);
     $plugin->setFailedRequestRepository(new FailedRequestRepository());
     $plugin->setOrderRepository(new OrderRepository());

--- a/includes/CreateLogisticsOrderCommand.php
+++ b/includes/CreateLogisticsOrderCommand.php
@@ -11,7 +11,7 @@ namespace Towa\GebruederWeissWooCommerce;
 
 defined('ABSPATH') || exit;
 
-use Towa\GebruederWeissSDK\Api\WriteApi;
+use Towa\GebruederWeissSDK\Api\DefaultApi;
 use Towa\GebruederWeissSDK\ApiException;
 use Towa\GebruederWeissWooCommerce\Exceptions\CreateLogisticsOrderConflictException;
 use Towa\GebruederWeissWooCommerce\Exceptions\CreateLogisticsOrderFailedException;
@@ -26,9 +26,9 @@ class CreateLogisticsOrderCommand
     /**
      * Gebrueder Weiss Write API client
      *
-     * @var WriteApi
+     * @var DefaultApi
      */
-    private $writeApi;
+    private $gebruederWeissApi;
 
     /**
      * WooCommerce Order to be processed
@@ -49,11 +49,11 @@ class CreateLogisticsOrderCommand
      *
      * @param object                $wooCommerceOrder WooCommerce order.
      * @param LogisticsOrderFactory $logisticsOrderFactory Factory for creating logistics orders.
-     * @param WriteApi              $writeApi Gebrueder Weiss Write API client.
+     * @param DefaultApi            $gebruederWeissApi Gebrueder Weiss Write API client.
      */
-    public function __construct(object $wooCommerceOrder, LogisticsOrderFactory $logisticsOrderFactory, WriteApi $writeApi)
+    public function __construct(object $wooCommerceOrder, LogisticsOrderFactory $logisticsOrderFactory, DefaultApi $gebruederWeissApi)
     {
-        $this->writeApi = $writeApi;
+        $this->gebruederWeissApi = $gebruederWeissApi;
         $this->wooCommerceOrder = $wooCommerceOrder;
         $this->logisticsOrderFactory = $logisticsOrderFactory;
     }
@@ -67,10 +67,10 @@ class CreateLogisticsOrderCommand
      */
     public function execute(): void
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->wooCommerceOrder);
+        $payload = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->wooCommerceOrder);
 
         try {
-            $this->writeApi->logisticsOrderPost($logisticsOrder);
+            $this->gebruederWeissApi->logisticsOrderPost("de-DE", $payload);
             $this->wooCommerceOrder->set_status("on-hold");
             $this->wooCommerceOrder->save();
         } catch (ApiException $e) {

--- a/includes/CreateLogisticsOrderCommand.php
+++ b/includes/CreateLogisticsOrderCommand.php
@@ -70,7 +70,7 @@ class CreateLogisticsOrderCommand
         $payload = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->wooCommerceOrder);
 
         try {
-            $this->gebruederWeissApi->logisticsOrderPost("de-DE", $payload);
+            $this->gebruederWeissApi->logisticsOrderPost("en-US", $payload);
             $this->wooCommerceOrder->set_status("on-hold");
             $this->wooCommerceOrder->save();
         } catch (ApiException $e) {

--- a/includes/FailedRequestQueue/RetryFailedRequestsQueueWorker.php
+++ b/includes/FailedRequestQueue/RetryFailedRequestsQueueWorker.php
@@ -9,7 +9,7 @@ namespace Towa\GebruederWeissWooCommerce\FailedRequestQueue;
 
 defined('ABSPATH') || exit;
 
-use Towa\GebruederWeissSDK\Api\WriteApi;
+use Towa\GebruederWeissSDK\Api\DefaultApi;
 use Towa\GebruederWeissWooCommerce\CreateLogisticsOrderCommand;
 use Towa\GebruederWeissWooCommerce\Exceptions\CreateLogisticsOrderConflictException;
 use Towa\GebruederWeissWooCommerce\Exceptions\CreateLogisticsOrderFailedException;
@@ -40,9 +40,9 @@ class RetryFailedRequestsQueueWorker
     /**
      * Gebrueder Weiss Write API
      *
-     * @var WriteApi
+     * @var DefaultApi
      */
-    private $writeApi = null;
+    private $gebruederWeissApi = null;
 
     /**
      * Order Repository
@@ -63,19 +63,19 @@ class RetryFailedRequestsQueueWorker
      *
      * @param FailedRequestRepository $failedRequestRepository Failed Requests Repository.
      * @param LogisticsOrderFactory   $logisticsOrderFactory Logistics Order Factory.
-     * @param WriteApi                $writeApi Gebrueder Weiss Write API.
+     * @param DefaultApi              $gebruederWeissApi Gebrueder Weiss Write API.
      * @param OrderRepository         $orderRepository WooCommerce Order Repository.
      * @param SettingsRepository      $settingsRepository Settings Repository.
      */
     public function __construct(
         FailedRequestRepository $failedRequestRepository,
         LogisticsOrderFactory $logisticsOrderFactory,
-        WriteApi $writeApi,
+        DefaultApi $gebruederWeissApi,
         OrderRepository $orderRepository,
         SettingsRepository $settingsRepository
     ) {
         $this->failedRequestRepository = $failedRequestRepository;
-        $this->writeApi = $writeApi;
+        $this->gebruederWeissApi = $gebruederWeissApi;
         $this->logisticsOrderFactory = $logisticsOrderFactory;
         $this->orderRepository = $orderRepository;
         $this->settingsRepository = $settingsRepository;
@@ -88,7 +88,7 @@ class RetryFailedRequestsQueueWorker
      */
     public function start(): void
     {
-        $this->writeApi->getConfig()->setAccessToken($this->settingsRepository->getAccessToken()->getToken());
+        $this->gebruederWeissApi->getConfig()->setAccessToken($this->settingsRepository->getAccessToken()->getToken());
 
         while (true) {
             $failedRequest = $this->failedRequestRepository->findOneToRetry();
@@ -109,7 +109,7 @@ class RetryFailedRequestsQueueWorker
                 (new CreateLogisticsOrderCommand(
                     $order,
                     $this->logisticsOrderFactory,
-                    $this->writeApi
+                    $this->gebruederWeissApi
                 ))->execute();
 
                 $failedRequest->setStatus(FailedRequest::SUCCESS_STATUS);

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -105,10 +105,13 @@ class LogisticsOrderFactory
 
         $fullName = implode(" ", array_filter([$wooCommerceOrder->get_shipping_first_name(), $wooCommerceOrder->get_shipping_last_name()]));
 
+        $email = $wooCommerceOrder->get_billing_email();
+        $phone = $wooCommerceOrder->get_billing_phone();
+
         $contact = new Contact();
         $contact->setName($fullName);
-        $contact->setEmail($wooCommerceOrder->get_billing_email());
-        $contact->setPhone($wooCommerceOrder->get_billing_phone());
+        $contact->setEmail(!empty($email) ? $email : null);
+        $contact->setPhone(!empty($phone) ? $phone : null);
         $contact->setLanguage("en-US");
         $logisticsAddress->setContact($contact);
 

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -73,7 +73,7 @@ class LogisticsOrderFactory
 
         $callbacks = new LogisticsOrderCallbacks();
         $callbacks->setSuccessCallback($this->settingsRepository->getSiteUrl() . "/wp-json/gebrueder-weiss-woocommerce/v1/orders/" . $wooCommerceOrder->get_id() . "/callbacks/success");
-        $callbacks->setFullfilledCallback($this->settingsRepository->getSiteUrl() . "/wp-json/gebrueder-weiss-woocommerce/v1/orders/" . $wooCommerceOrder->get_id() . "/callbacks/fulfilled");
+        $callbacks->setFullfilledCallback($this->settingsRepository->getSiteUrl() . "/wp-json/gebrueder-weiss-woocommerce/v1/orders/" . $wooCommerceOrder->get_id() . "/callbacks/fulfillment");
 
         $payload->setCallbacks($callbacks);
 

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -14,7 +14,7 @@ use Towa\GebruederWeissSDK\Model\AddressReference;
 use Towa\GebruederWeissSDK\Model\Article;
 use Towa\GebruederWeissSDK\Model\ArticleNote;
 use Towa\GebruederWeissSDK\Model\Contact;
-use Towa\GebruederWeissSDK\Model\InlineObject;
+use Towa\GebruederWeissSDK\Model\InlineObject as CreateLogisticsOrderPayload;
 use Towa\GebruederWeissSDK\Model\LingualText;
 use Towa\GebruederWeissSDK\Model\LogisticsAddress;
 use Towa\GebruederWeissSDK\Model\LogisticsOrder;
@@ -50,11 +50,11 @@ class LogisticsOrderFactory
      * Creates a logistics order from a WooCommerce order
      *
      * @param object $wooCommerceOrder The order to be converted into a logistics order.
-     * @return InlineObject
+     * @return CreateLogisticsOrderPayload
      */
-    public function buildFromWooCommerceOrder(object $wooCommerceOrder): InlineObject
+    public function buildFromWooCommerceOrder(object $wooCommerceOrder): CreateLogisticsOrderPayload
     {
-        $payload = new InlineObject();
+        $payload = new CreateLogisticsOrderPayload();
 
         $logisticsOrder = new LogisticsOrder();
         $logisticsOrder->setCreationDateTime($wooCommerceOrder->get_date_created());

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -109,7 +109,7 @@ class LogisticsOrderFactory
         $contact->setName($fullName);
         $contact->setEmail($wooCommerceOrder->get_billing_email());
         $contact->setPhone($wooCommerceOrder->get_billing_phone());
-        $contact->setLanguage("de-DE");
+        $contact->setLanguage("en-US");
         $logisticsAddress->setContact($contact);
 
         return $logisticsAddress;
@@ -149,7 +149,7 @@ class LogisticsOrderFactory
             $orderLine->setQuantity($orderItem->get_quantity());
 
             $customerNote = new LingualText();
-            $customerNote->setLanguage("de-DE");
+            $customerNote->setLanguage("en-US");
             $customerNote->setText($wooCommerceOrder->get_customer_note());
 
             $logisticsRequirementNote = new OrderLineNote();

--- a/includes/Options/Option.php
+++ b/includes/Options/Option.php
@@ -157,7 +157,7 @@ class Option implements CanRender
             $this->slug,
             $this->name,
             [$this, 'render'],
-            Plugin::OPTIONPAGESLUG,
+            Plugin::OPTION_PAGE_SLUG,
             $this->group,
         );
     }

--- a/includes/Options/OrderOptionsTab.php
+++ b/includes/Options/OrderOptionsTab.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Fulfillment Options Tab
+ * Order Options Tab
  *
  * @package Options
  */
@@ -18,13 +18,11 @@ class FulfillmentOptionsTab extends Tab
 {
 
     /**
-     * Creates the fulfillment options based on the passed states.
-     *
-     * @param array $orderStates The states to be shown as options in the dropdowns.
+     * Creates the order options tab
      */
-    public function __construct(array $orderStates)
+    public function __construct()
     {
-        parent::__construct(__('Fulfillment', Plugin::LANGUAGE_DOMAIN), 'fulfillment');
+        parent::__construct(__('Order', Plugin::LANGUAGE_DOMAIN), 'fulfillment');
         $this
             ->addOption(new OptionDropdown('Fulfillment State', 'fulfillmentState', __('Fulfillment State', Plugin::LANGUAGE_DOMAIN), 'fulfillment', $orderStates))
             ->addOption(new OptionDropdown('Fulfilled State', 'fulfilledState', __('Fulfilled State', Plugin::LANGUAGE_DOMAIN), 'fulfillment', $orderStates))

--- a/includes/Options/OrderOptionsTab.php
+++ b/includes/Options/OrderOptionsTab.php
@@ -12,20 +12,69 @@ defined('ABSPATH') || exit;
 use Towa\GebruederWeissWooCommerce\Plugin;
 
 /**
- * Fulfillment Options Tab
+ * Order Options Tab
  */
-class FulfillmentOptionsTab extends Tab
+class OrderOptionsTab extends Tab
 {
+    const TAB_SLUG = 'order';
+    const ORDER_ID_FIELD_NAME = 'order_id_field';
+    const ORDER_ID_FIELD_DEFAULT_VALUE = "gbw_order_id";
+    const TRACKING_LINK_FIELD_NAME = 'tracking_link_field';
+    const TRACKING_LINK_FIELD_DEFAULT_VALUE = "gbw_tracking_link";
+    const CARRIER_INFORMATION_FIELD_NAME = 'carrier_information_field';
+    const CARRIER_INFORMATION_FIELD_DEFAULT_VALUE = "gbw_carrier_information";
 
     /**
      * Creates the order options tab
+     *
+     * @param array $orderCustomFields Custom fields available for orders.
      */
-    public function __construct()
+    public function __construct($orderCustomFields)
     {
-        parent::__construct(__('Order', Plugin::LANGUAGE_DOMAIN), 'fulfillment');
+        parent::__construct(__('Order', Plugin::LANGUAGE_DOMAIN), self::TAB_SLUG);
+
+        $options = $this->createOptionsFromFieldKeys($orderCustomFields);
+        $orderIdOptions = $this->addDefaultValueToOptions($options, self::ORDER_ID_FIELD_DEFAULT_VALUE);
+        $trackingLinkOptions = $this->addDefaultValueToOptions($options, self::TRACKING_LINK_FIELD_DEFAULT_VALUE);
+        $carrierInformationOptions = $this->addDefaultValueToOptions($options, self::CARRIER_INFORMATION_FIELD_DEFAULT_VALUE);
+
         $this
-            ->addOption(new OptionDropdown('Fulfillment State', 'fulfillmentState', __('Fulfillment State', Plugin::LANGUAGE_DOMAIN), 'fulfillment', $orderStates))
-            ->addOption(new OptionDropdown('Fulfilled State', 'fulfilledState', __('Fulfilled State', Plugin::LANGUAGE_DOMAIN), 'fulfillment', $orderStates))
-            ->addOption(new OptionDropdown('Fulfillment Error State', 'fulfillmentErrorState', __('Fulfillment Error State', Plugin::LANGUAGE_DOMAIN), 'fulfillment', $orderStates));
+            ->addOption(new OptionDropdown('Order Id Field', self::ORDER_ID_FIELD_NAME, __('Order Id Field', Plugin::LANGUAGE_DOMAIN), self::TAB_SLUG, $orderIdOptions))
+            ->addOption(new OptionDropdown('Tracking Link Field', self::TRACKING_LINK_FIELD_NAME, __('Tracking Link Field', Plugin::LANGUAGE_DOMAIN), self::TAB_SLUG, $trackingLinkOptions))
+            ->addOption(new OptionDropdown('Carrier Information Field', self::CARRIER_INFORMATION_FIELD_NAME, __('Carrier Information Field', Plugin::LANGUAGE_DOMAIN), self::TAB_SLUG, $carrierInformationOptions));
+    }
+
+    /**
+     * Creates options from field keys
+     *
+     * @param array $orderCustomFields Custom fields available for orders.
+     * @return array
+     */
+    private function createOptionsFromFieldKeys(array $orderCustomFields): array
+    {
+        $options = [];
+        foreach ($orderCustomFields as $orderCustomField) {
+            $options[$orderCustomField] = $orderCustomField;
+        }
+
+        return $options;
+    }
+
+    /**
+     * Adds a default value to the options
+     *
+     * @param array  $options Options to add the default value to.
+     * @param string $defaultValue Default value to add.
+     * @return array
+     */
+    private function addDefaultValueToOptions(array $options, string $defaultValue): array
+    {
+        if (array_key_exists($defaultValue, $options)) {
+            return $options;
+        }
+
+        $options[$defaultValue] = $defaultValue;
+
+        return $options;
     }
 }

--- a/includes/Options/Tab.php
+++ b/includes/Options/Tab.php
@@ -79,7 +79,7 @@ class Tab implements CanRender
      * @param array  $options Options which should be displayed on the tab.
      * @param string $page Slug of the options page where the tab should be displayed.
      */
-    public function __construct(string $name, string $slug, array $options = [], string $page = Plugin::OPTIONPAGESLUG)
+    public function __construct(string $name, string $slug, array $options = [], string $page = Plugin::OPTION_PAGE_SLUG)
     {
         $this->name = $name;
         $this->slug = $slug;

--- a/includes/OrderController.php
+++ b/includes/OrderController.php
@@ -11,10 +11,8 @@ namespace Towa\GebruederWeissWooCommerce;
 
 defined('ABSPATH') || exit;
 
-use Towa\GebruederWeissSDK\Model\InlineObject1;
-use Towa\GebruederWeissSDK\Model\InlineObject2;
-use Towa\GebruederWeissWooCommerce\Options\Option;
-use Towa\GebruederWeissWooCommerce\Options\OrderOptionsTab;
+use Towa\GebruederWeissSDK\Model\InlineObject1 as SuccessCallbackBody;
+use Towa\GebruederWeissSDK\Model\InlineObject2 as FulfilledCallbackBody;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -68,7 +66,7 @@ class OrderController
     {
         $id = $request->get_params()['id'];
         $requestBody = $request->get_body();
-        $data = new InlineObject1(json_decode($requestBody, true));
+        $data = new SuccessCallbackBody(json_decode($requestBody, true));
 
         $order = $this->orderRepository->findById($id);
 
@@ -93,7 +91,7 @@ class OrderController
     {
         $id = $request->get_params()['id'];
         $requestBody = $request->get_body();
-        $data = new InlineObject2(json_decode($requestBody, true));
+        $data = new FulfilledCallbackBody(json_decode($requestBody, true));
 
         $order = $this->orderRepository->findById($id);
 

--- a/includes/OrderController.php
+++ b/includes/OrderController.php
@@ -47,7 +47,7 @@ class OrderController
         $this->orderRepository = $orderRepository;
 
         \add_action('rest_api_init', function () {
-            register_rest_route(self::NAMESPACE, '/update/(?P<id>\d+)', [
+            register_rest_route(self::NAMESPACE, '/orders/(?P<id>\d+)/callbacks/success', [
                 'methods' => 'POST',
                 'callback' => [$this, 'handleOrderUpdateRequest'],
                 'permission_callback' => '__return_true'

--- a/includes/OrderController.php
+++ b/includes/OrderController.php
@@ -77,6 +77,14 @@ class OrderController
             return new WP_REST_Response(null, 404, null);
         }
 
+        if (empty($data)) {
+            return new WP_REST_Response(['message' => 'Invalid payload'], 422);
+        }
+
+        if (empty($data->orderId)) {
+            return new WP_REST_Response(['message' => 'Missing orderId'], 422);
+        }
+
         $order->update_meta_data($this->settings->getOrderIdFieldName(), $data->orderId);
 
         $order->save();
@@ -99,6 +107,18 @@ class OrderController
 
         if (is_null($order)) {
             return new WP_REST_Response(null, 404, null);
+        }
+
+        if (empty($data)) {
+            return new WP_REST_Response(['message' => 'Invalid payload'], 422);
+        }
+
+        if (empty($data->trackingUrl)) {
+            return new WP_REST_Response(['message' => 'Missing trackingUrl'], 422);
+        }
+
+        if (empty($data->transportProduct)) {
+            return new WP_REST_Response(['message' => 'Missing trackingProduct'], 422);
         }
 
         $order->set_status($this->settings->getFulfilledState());

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -30,20 +30,12 @@ use Towa\GebruederWeissWooCommerce\Support\WordPress;
  */
 final class Plugin extends Singleton
 {
-    /**
-     * Option Page Slug
-     */
     const OPTION_PAGE_SLUG = 'gbw-woocommerce';
 
     const RETRY_REQUESTS_CRON_JOB = "gbw_retry_failed_requests";
 
     const CRON_EVERY_FIVE_MINUTES = "gbw_every_five_minutes";
 
-    /**
-     * Plugin Language Domain
-     *
-     * @var string
-     */
     const LANGUAGE_DOMAIN = 'gbw-woocommerce';
 
     /**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -33,7 +33,7 @@ final class Plugin extends Singleton
     /**
      * Option Page Slug
      */
-    const OPTIONPAGESLUG = 'gbw-woocommerce';
+    const OPTION_PAGE_SLUG = 'gbw-woocommerce';
 
     const RETRY_REQUESTS_CRON_JOB = "gbw_retry_failed_requests";
 
@@ -122,7 +122,7 @@ final class Plugin extends Singleton
      */
     public function initOptionPage(): void
     {
-        $optionsPage = new OptionPage('options', self::OPTIONPAGESLUG);
+        $optionsPage = new OptionPage('options', self::OPTION_PAGE_SLUG);
         $accountTab = (new Tab(__('Account', self::LANGUAGE_DOMAIN), 'account'))->onTabInit([$this, 'validateCredentials']);
 
         $accountTab
@@ -339,7 +339,7 @@ final class Plugin extends Singleton
             __('options', 'gbw-woocommerce'),
             __('Gebrüder Weiss Woocommerce', 'gbw-woocommerce'),
             'manage_options',
-            self::OPTIONPAGESLUG,
+            self::OPTION_PAGE_SLUG,
             [$this, 'renderOptionPage']
         );
     }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -44,7 +44,7 @@ final class Plugin extends Singleton
      *
      * @var string
      */
-    public static $languageDomain = 'gbw-woocommerce';
+    const LANGUAGE_DOMAIN = 'gbw-woocommerce';
 
     /**
      * Options Page
@@ -123,12 +123,12 @@ final class Plugin extends Singleton
     public function initOptionPage(): void
     {
         $optionsPage = new OptionPage('options', self::OPTIONPAGESLUG);
-        $accountTab = (new Tab(__('Account', self::$languageDomain), 'account'))->onTabInit([$this, 'validateCredentials']);
+        $accountTab = (new Tab(__('Account', self::LANGUAGE_DOMAIN), 'account'))->onTabInit([$this, 'validateCredentials']);
 
         $accountTab
-            ->addOption(new Option('Customer Id', 'customer_id', __('Customer Id', self::$languageDomain), 'account', 'integer'))
-            ->addOption(new Option('Client Id', 'client_id', __('Client Id', self::$languageDomain), 'account', 'string'))
-            ->addOption(new Option('Client Secret', 'client_secret', __('Client Secret', self::$languageDomain), 'account', 'string'));
+            ->addOption(new Option('Customer Id', 'customer_id', __('Customer Id', self::LANGUAGE_DOMAIN), 'account', 'integer'))
+            ->addOption(new Option('Client Id', 'client_id', __('Client Id', self::LANGUAGE_DOMAIN), 'account', 'string'))
+            ->addOption(new Option('Client Secret', 'client_secret', __('Client Secret', self::LANGUAGE_DOMAIN), 'account', 'string'));
         $optionsPage->addTab($accountTab);
 
         $orderStatuses = $this->orderStateRepository->getAllOrderStates();
@@ -182,12 +182,12 @@ final class Plugin extends Singleton
         try {
             $token = $this->authenticationClient->authenticate();
             if ($token && $token->isValid()) {
-                self::showWordpressAdminSuccessMessage(__("Your credentials were successfully validated.", self::$languageDomain));
+                self::showWordpressAdminSuccessMessage(__("Your credentials were successfully validated.", self::LANGUAGE_DOMAIN));
             } else {
-                self::showWordpressAdminErrorMessage(__("Your credentials were not accepted by the Gebrüder Weiss API.", self::$languageDomain));
+                self::showWordpressAdminErrorMessage(__("Your credentials were not accepted by the Gebrüder Weiss API.", self::LANGUAGE_DOMAIN));
             }
         } catch (\Exception $e) {
-            self::showWordpressAdminErrorMessage(__("Sending an authentication request to the Gebrüder Weiss API Failed.", self::$languageDomain));
+            self::showWordpressAdminErrorMessage(__("Sending an authentication request to the Gebrüder Weiss API Failed.", self::LANGUAGE_DOMAIN));
         }
     }
 
@@ -200,14 +200,14 @@ final class Plugin extends Singleton
     {
         if (!self::pluginIsCompatibleWithCurrentPhpVersion()) {
             self::showWordpressAdminErrorMessage(
-                __("Gebrüder Weiss WooCommerce is not compatible with PHP " . phpversion() . ".", self::$languageDomain)
+                __("Gebrüder Weiss WooCommerce is not compatible with PHP " . phpversion() . ".", self::LANGUAGE_DOMAIN)
             );
             return false;
         }
 
         if (!self::isWooCommerceActive()) {
             self::showWordpressAdminErrorMessage(
-                __("Gebrüder Weiss WooCommerce requires WooCommerce to be installed and active.", self::$languageDomain)
+                __("Gebrüder Weiss WooCommerce requires WooCommerce to be installed and active.", self::LANGUAGE_DOMAIN)
             );
             return false;
         }
@@ -233,19 +233,19 @@ final class Plugin extends Singleton
 
         if ($fulfillmentState === $fulfilledState) {
             $this->showWordpressAdminErrorMessage(
-                __("The Gebrüder Weiss WooCommerce Plugin settings for Fulfillment State and Fulfilled State are set to the same state.", self::$languageDomain)
+                __("The Gebrüder Weiss WooCommerce Plugin settings for Fulfillment State and Fulfilled State are set to the same state.", self::LANGUAGE_DOMAIN)
             );
         }
 
         if ($fulfillmentState === $fulfillmentErrorState) {
             $this->showWordpressAdminErrorMessage(
-                __("The Gebrüder Weiss WooCommerce Plugin settings for Fulfillment State and Fulfillment Error State are set to the same state.", self::$languageDomain)
+                __("The Gebrüder Weiss WooCommerce Plugin settings for Fulfillment State and Fulfillment Error State are set to the same state.", self::LANGUAGE_DOMAIN)
             );
         }
 
         if ($fulfilledState === $fulfillmentErrorState) {
             $this->showWordpressAdminErrorMessage(
-                __("The Gebrüder Weiss WooCommerce Plugin settings for Fulfilled State and Fulfillment Error State are set to the same state.", self::$languageDomain)
+                __("The Gebrüder Weiss WooCommerce Plugin settings for Fulfilled State and Fulfillment Error State are set to the same state.", self::LANGUAGE_DOMAIN)
             );
         }
     }
@@ -478,14 +478,14 @@ final class Plugin extends Singleton
     {
         if (!$optionValue) {
             $this->showWordpressAdminErrorMessage(
-                __("The Gebrüder Weiss WooCommerce Plugin settings are missing a value for " . $displayName . ".", self::$languageDomain)
+                __("The Gebrüder Weiss WooCommerce Plugin settings are missing a value for " . $displayName . ".", self::LANGUAGE_DOMAIN)
             );
             return;
         }
 
         if (!$this->checkIfWooCommerceOrderStateExists($optionValue)) {
             $this->showWordpressAdminErrorMessage(
-                __("The selected order state for " . $displayName . " in the options for the Gebrüder Weiss WooCommerce Plugin does not exist in WooCommerce.", self::$languageDomain)
+                __("The selected order state for " . $displayName . " in the options for the Gebrüder Weiss WooCommerce Plugin does not exist in WooCommerce.", self::LANGUAGE_DOMAIN)
             );
         }
     }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -23,6 +23,7 @@ use Towa\GebruederWeissWooCommerce\Exceptions\CreateLogisticsOrderConflictExcept
 use Towa\GebruederWeissWooCommerce\Exceptions\CreateLogisticsOrderFailedException;
 use Towa\GebruederWeissWooCommerce\FailedRequestQueue\FailedRequestRepository;
 use Towa\GebruederWeissWooCommerce\FailedRequestQueue\RetryFailedRequestsQueueWorker;
+use Towa\GebruederWeissWooCommerce\Options\OrderOptionsTab;
 use Towa\GebruederWeissWooCommerce\Support\WordPress;
 
 /**
@@ -128,6 +129,9 @@ final class Plugin extends Singleton
         $fulfillmentTab = new FulfillmentOptionsTab($orderStatuses);
 
         $optionsPage->addTab($fulfillmentTab);
+
+        $orderMetaKeys = Wordpress::getAllMetaKeysForPostType('shop_order');
+        $optionsPage->addTab(new OrderOptionsTab($orderMetaKeys));
 
         $this->setOptionPage($optionsPage);
     }
@@ -358,6 +362,7 @@ final class Plugin extends Singleton
     {
         self::createRequestQueueTable();
         self::addCronIntervals();
+        self::setOrderOptionsDefaults();
 
         WordPress::scheduleCronjob(self::RETRY_REQUESTS_CRON_JOB, time(), self::CRON_EVERY_FIVE_MINUTES);
     }
@@ -623,5 +628,25 @@ final class Plugin extends Singleton
         global $wpdb;
         $sql = "DROP TABLE IF EXISTS `{$wpdb->base_prefix}gbw_request_retry_queue`";
         $wpdb->query($sql);
+    }
+
+    /**
+     * Sets the default values for the order options.
+     *
+     * @return void
+     */
+    private static function setOrderOptionsDefaults(): void
+    {
+        if (!WordPress::getOption(Option::OPTIONS_PREFIX . OrderOptionsTab::ORDER_ID_FIELD_NAME)) {
+            WordPress::updateOption(Option::OPTIONS_PREFIX . OrderOptionsTab::ORDER_ID_FIELD_NAME, OrderOptionsTab::ORDER_ID_FIELD_DEFAULT_VALUE);
+        }
+
+        if (!Wordpress::getOption(Option::OPTIONS_PREFIX . OrderOptionsTab::CARRIER_INFORMATION_FIELD_NAME)) {
+            WordPress::updateOption(Option::OPTIONS_PREFIX . OrderOptionsTab::CARRIER_INFORMATION_FIELD_NAME, OrderOptionsTab::CARRIER_INFORMATION_FIELD_DEFAULT_VALUE);
+        }
+
+        if (!Wordpress::getOption(Option::OPTIONS_PREFIX . OrderOptionsTab::TRACKING_LINK_FIELD_NAME)) {
+            WordPress::updateOption(Option::OPTIONS_PREFIX . OrderOptionsTab::TRACKING_LINK_FIELD_NAME, OrderOptionsTab::TRACKING_LINK_FIELD_DEFAULT_VALUE);
+        }
     }
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -18,7 +18,7 @@ use Towa\GebruederWeissWooCommerce\Options\Option;
 use Towa\GebruederWeissWooCommerce\Options\OptionPage;
 use Towa\GebruederWeissWooCommerce\Options\Tab;
 use Towa\GebruederWeissWooCommerce\Support\Singleton;
-use Towa\GebruederWeissSDK\Api\WriteApi;
+use Towa\GebruederWeissSDK\Api\DefaultApi;
 use Towa\GebruederWeissWooCommerce\Exceptions\CreateLogisticsOrderConflictException;
 use Towa\GebruederWeissWooCommerce\Exceptions\CreateLogisticsOrderFailedException;
 use Towa\GebruederWeissWooCommerce\FailedRequestQueue\FailedRequestRepository;
@@ -70,9 +70,9 @@ final class Plugin extends Singleton
     /**
      * Client for writing to the Gebrueder Weiss API.
      *
-     * @var WriteApi
+     * @var DefaultApi
      */
-    private $writeApiClient = null;
+    private $gebruederWeissApiClient = null;
 
     /**
      * Factory for building logistics orders.
@@ -279,10 +279,10 @@ final class Plugin extends Singleton
     public function createLogisticsOrderAndUpdateOrderState(object $order)
     {
         $authToken = $this->settingsRepository->getAccessToken();
-        $this->writeApiClient->getConfig()->setAccessToken($authToken->getToken());
+        $this->gebruederWeissApiClient->getConfig()->setAccessToken($authToken->getToken());
 
         try {
-            (new CreateLogisticsOrderCommand($order, $this->logisticsOrderFactory, $this->writeApiClient))->execute();
+            (new CreateLogisticsOrderCommand($order, $this->logisticsOrderFactory, $this->gebruederWeissApiClient))->execute();
         } catch (CreateLogisticsOrderConflictException $e) {
             $order->set_status($this->settingsRepository->getFulfillmentErrorState());
             $order->save();
@@ -306,7 +306,7 @@ final class Plugin extends Singleton
         (new RetryFailedRequestsQueueWorker(
             $this->failedRequestRepository,
             $this->logisticsOrderFactory,
-            $this->writeApiClient,
+            $this->gebruederWeissApiClient,
             $this->orderRepository,
             $this->settingsRepository
         ))->start();
@@ -434,12 +434,12 @@ final class Plugin extends Singleton
     /**
      * Sets the client for writing to the Gebrueder Weiss API.
      *
-     * @param WriteApi $client The client for writing to the api.
+     * @param DefaultApi $client The client for writing to the api.
      * @return void
      */
-    public function setWriteApiClient(WriteApi $client): void
+    public function setGebruederWeissApiClient(DefaultApi $client): void
     {
-        $this->writeApiClient = $client;
+        $this->gebruederWeissApiClient = $client;
     }
 
     /**

--- a/includes/SettingsRepository.php
+++ b/includes/SettingsRepository.php
@@ -14,6 +14,7 @@ defined('ABSPATH') || exit;
 use Exception;
 use Towa\GebruederWeissWooCommerce\OAuth\OAuthToken;
 use Towa\GebruederWeissWooCommerce\Options\Option;
+use Towa\GebruederWeissWooCommerce\Options\OrderOptionsTab;
 use Towa\GebruederWeissWooCommerce\Support\WordPress;
 
 /**
@@ -119,6 +120,36 @@ class SettingsRepository
     }
 
     /**
+     * Reads the custom field name for the order id from the plugin settings.
+     *
+     * @return integer|null
+     */
+    public function getOrderIdFieldName(): string
+    {
+        return $this->getOption(OrderOptionsTab::ORDER_ID_FIELD_NAME, OrderOptionsTab::ORDER_ID_FIELD_DEFAULT_VALUE);
+    }
+
+    /**
+     * Reads the custom field name for the tracking link from the plugin settings.
+     *
+     * @return integer|null
+     */
+    public function getTrackingLinkFieldName(): string
+    {
+        return $this->getOption(OrderOptionsTab::TRACKING_LINK_FIELD_NAME, OrderOptionsTab::TRACKING_LINK_FIELD_DEFAULT_VALUE);
+    }
+
+    /**
+     * Reads the custom field name for the carrier information from the plugin settings.
+     *
+     * @return integer|null
+     */
+    public function getCarrierInformationFieldName(): string
+    {
+        return $this->getOption(OrderOptionsTab::CARRIER_INFORMATION_FIELD_NAME, OrderOptionsTab::CARRIER_INFORMATION_FIELD_DEFAULT_VALUE);
+    }
+
+    /**
      * Reads the wordpress site URL from the options.
      *
      * @return string|null
@@ -131,12 +162,13 @@ class SettingsRepository
     /**
      * Reads the plugin option with the passed name from the wordpress options
      *
-     * @param string $name The name of the option.
+     * @param string     $name The name of the option.
+     * @param mixed|null $default The default value to return if the option is not set.
      * @return mixed
      */
-    private function getOption(string $name)
+    private function getOption(string $name, $default = null)
     {
-        return WordPress::getOption(Option::OPTIONS_PREFIX . $name, null);
+        return WordPress::getOption(Option::OPTIONS_PREFIX . $name, $default);
     }
 
     /**

--- a/includes/Support/TwigEnvironment.php
+++ b/includes/Support/TwigEnvironment.php
@@ -63,7 +63,7 @@ class TwigEnvironment extends Singleton
         $this->twig->addFunction(new TwigFunction('do_settings_sections', function ($group) {
             \do_settings_sections($group);
         }));
-        $this->twig->addFunction(new TwigFunction('do_settings_fields', function ($section, $page = Plugin::OPTIONPAGESLUG) {
+        $this->twig->addFunction(new TwigFunction('do_settings_fields', function ($section, $page = Plugin::OPTION_PAGE_SLUG) {
             \do_settings_fields($page, $section);
         }));
         $this->twig->addFunction(new TwigFunction('esc_attr', function ($attribute) {

--- a/includes/Support/WordPress.php
+++ b/includes/Support/WordPress.php
@@ -118,4 +118,27 @@ class WordPress
     {
         \wp_clear_scheduled_hook($hook);
     }
+
+    /**
+     * Returns all meta field keys for the given post type
+     *
+     * @param string $postType The post type to get the meta keys for.
+     * @return array
+     */
+    public static function getAllMetaKeysForPostType(string $postType): array
+    {
+        global $wpdb;
+
+        $query = "
+            SELECT DISTINCT($wpdb->postmeta.meta_key) 
+            FROM $wpdb->posts 
+            LEFT JOIN $wpdb->postmeta 
+            ON $wpdb->posts.ID = $wpdb->postmeta.post_id 
+            WHERE $wpdb->posts.post_type = '%s'
+            # exclude hidden meta keys
+            AND $wpdb->postmeta.meta_key NOT RegExp '(^[_0-9].+$)' 
+        ";
+
+        return $wpdb->get_col($wpdb->prepare($query, $postType));
+    }
 }

--- a/tests/Integration/OrderControllerTest.php
+++ b/tests/Integration/OrderControllerTest.php
@@ -14,39 +14,7 @@ class OrderControllerTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    public function test_it_does_update_the_woocommerce_order_status()
-    {
-        /** @var \WP_REST_Request|MockInterface */
-        $request = Mockery::mock(\WP_REST_Request::class);
-        $request->allows('get_params')->andReturn(['id' => 12]);
-
-        /** @var SettingsRepository|MockInterface */
-        $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows(['getFulfilledState' => 'wc-fulfilled']);
-
-        /** @var MockInterface|\WC_Order */
-        $order = Mockery::mock("WC_Order");
-        $order->allows("set_status");
-        $order->allows("get_status");
-        $order->allows("save");
-
-        /** @var MockInterface|OrderRepository */
-        $orderRepository = Mockery::mock(OrderRepository::class);
-        $orderRepository->allows([
-            "findById" => $order
-        ]);
-
-        $controller = new OrderController($settingsRepository, $orderRepository);
-
-
-        $controller->handleOrderUpdateRequest($request);
-
-
-        $order->shouldHaveReceived('set_status', ['wc-fulfilled']);
-        $order->shouldHaveReceived('save');
-    }
-
-    public function test_it_returns_a_404_response_if_no_order_with_the_given_id_exists()
+    public function test_the_success_callback_returns_a_404_response_if_no_order_with_the_given_id_exists()
     {
         /** @var SettingsRepository|MockInterface */
         $settingsRepository = Mockery::mock(SettingsRepository::class);
@@ -55,6 +23,7 @@ class OrderControllerTest extends TestCase
         /** @var \WP_REST_Request|MockInterface */
         $request = Mockery::mock(\WP_REST_Request::class);
         $request->allows('get_params')->andReturn(['id' => 12]);
+        $request->allows('get_body')->andReturn('{"order_id": 12}');
 
         /** @var MockInterface|OrderRepository */
         $orderRepository = Mockery::mock(OrderRepository::class);
@@ -65,22 +34,25 @@ class OrderControllerTest extends TestCase
         $controller = new OrderController($settingsRepository, $orderRepository);
 
 
-        $response = $controller->handleOrderUpdateRequest($request);
+        $response = $controller->handleSuccessCallback($request);
 
 
         $this->assertEquals(404, $response->status);
     }
 
-    public function test_it_returns_a_200_response_if_a_order_with_the_given_id_exists()
+    public function test_the_success_callback_returns_a_200_response_if_a_order_with_the_given_id_exists()
     {
         /** @var SettingsRepository|MockInterface */
         $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows(['getFulfilledState' => 'wc-fulfilled']);
+        $settingsRepository->allows([
+            'getFulfilledState' => 'wc-fulfilled',
+            'getOrderIdFieldName' => 'order_id'
+        ]);
 
         /** @var MockInterface|\WC_Order */
         $order = Mockery::mock("WC_Order");
-        $order->allows("set_status");
         $order->allows("get_status");
+        $order->allows("update_meta_data");
         $order->allows("save");
 
         /** @var MockInterface|OrderRepository */
@@ -92,13 +64,176 @@ class OrderControllerTest extends TestCase
         /** @var \WP_REST_Request|MockInterface */
         $request = Mockery::mock(\WP_REST_Request::class);
         $request->allows('get_params')->andReturn(['id' => 12]);
+        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
 
         $controller = new OrderController($settingsRepository, $orderRepository);
 
-
-        $response = $controller->handleOrderUpdateRequest($request);
-
+        $response = $controller->handleSuccessCallback($request);
 
         $this->assertEquals(200, $response->status);
+    }
+
+    public function test_the_success_callback_updates_the_order_id()
+    {
+        /** @var SettingsRepository|MockInterface */
+        $settingsRepository = Mockery::mock(SettingsRepository::class);
+        $settingsRepository->allows([
+            'getFulfilledState' => 'wc-fulfilled',
+            'getOrderIdFieldName' => 'order_id'
+        ]);
+
+        /** @var MockInterface|\WC_Order */
+        $order = Mockery::mock("WC_Order");
+        $order->allows("get_status");
+        $order->allows("update_meta_data");
+        $order->allows("save");
+
+        /** @var MockInterface|OrderRepository */
+        $orderRepository = Mockery::mock(OrderRepository::class);
+        $orderRepository->allows([
+            "findById" => $order
+        ]);
+
+        /** @var \WP_REST_Request|MockInterface */
+        $request = Mockery::mock(\WP_REST_Request::class);
+        $request->allows('get_params')->andReturn(['id' => 12]);
+        $request->allows('get_body')->andReturn('{"order_id": 13, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+
+        $controller = new OrderController($settingsRepository, $orderRepository);
+
+        $controller->handleSuccessCallback($request);
+
+        $order->shouldHaveReceived("update_meta_data")->with("order_id", 13);
+        $order->shouldHaveReceived("save");
+    }
+
+    public function test_the_fulfillment_callback_updates_the_woocommerce_order_status()
+    {
+        /** @var \WP_REST_Request|MockInterface */
+        $request = Mockery::mock(\WP_REST_Request::class);
+        $request->allows('get_params')->andReturn(['id' => 12]);
+        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+
+        /** @var SettingsRepository|MockInterface */
+        $settingsRepository = Mockery::mock(SettingsRepository::class);
+        $settingsRepository->allows([
+            'getFulfilledState' => 'wc-fulfilled',
+            'getTrackingLinkFieldName' => 'tracking_id',
+            'getCarrierInformationFieldName' => 'carrier_information'
+        ]);
+
+        /** @var MockInterface|\WC_Order */
+        $order = Mockery::mock("WC_Order");
+        $order->allows("set_status");
+        $order->allows("get_status");
+        $order->allows("update_meta_data");
+        $order->allows("save");
+
+        /** @var MockInterface|OrderRepository */
+        $orderRepository = Mockery::mock(OrderRepository::class);
+        $orderRepository->allows([
+            "findById" => $order
+        ]);
+
+        $controller = new OrderController($settingsRepository, $orderRepository);
+
+        $controller->handleFulfillmentCallback($request);
+
+        $order->shouldHaveReceived("set_status")->with("wc-fulfilled");
+        $order->shouldHaveReceived('save');
+    }
+
+    public function test_the_fulfillment_callback_updates_the_order_meta_data()
+    {
+        /** @var \WP_REST_Request|MockInterface */
+        $request = Mockery::mock(\WP_REST_Request::class);
+        $request->allows('get_params')->andReturn(['id' => 12]);
+        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+
+        /** @var SettingsRepository|MockInterface */
+        $settingsRepository = Mockery::mock(SettingsRepository::class);
+        $settingsRepository->allows([
+            'getFulfilledState' => 'wc-fulfilled',
+            'getTrackingLinkFieldName' => 'tracking_id',
+            'getCarrierInformationFieldName' => 'carrier_information'
+        ]);
+
+        /** @var MockInterface|\WC_Order */
+        $order = Mockery::mock("WC_Order");
+        $order->allows("set_status");
+        $order->allows("get_status");
+        $order->allows("update_meta_data");
+        $order->allows("save");
+
+        /** @var MockInterface|OrderRepository */
+        $orderRepository = Mockery::mock(OrderRepository::class);
+        $orderRepository->allows([
+            "findById" => $order
+        ]);
+
+        $controller = new OrderController($settingsRepository, $orderRepository);
+
+        $controller->handleFulfillmentCallback($request);
+
+        $order->shouldHaveReceived("update_meta_data")->with("tracking_id", "http://example.com");
+        $order->shouldHaveReceived("update_meta_data")->with("carrier_information", "DHL");
+    }
+
+    public function test_the_fulfillment_callback_returns_200_on_success()
+    {
+        /** @var \WP_REST_Request|MockInterface */
+        $request = Mockery::mock(\WP_REST_Request::class);
+        $request->allows('get_params')->andReturn(['id' => 12]);
+        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+
+        /** @var SettingsRepository|MockInterface */
+        $settingsRepository = Mockery::mock(SettingsRepository::class);
+        $settingsRepository->allows([
+            'getFulfilledState' => 'wc-fulfilled',
+            'getTrackingLinkFieldName' => 'tracking_id',
+            'getCarrierInformationFieldName' => 'carrier_information'
+        ]);
+
+        /** @var MockInterface|\WC_Order */
+        $order = Mockery::mock("WC_Order");
+        $order->allows("set_status");
+        $order->allows("get_status");
+        $order->allows("update_meta_data");
+        $order->allows("save");
+
+        /** @var MockInterface|OrderRepository */
+        $orderRepository = Mockery::mock(OrderRepository::class);
+        $orderRepository->allows([
+            "findById" => $order
+        ]);
+
+        $controller = new OrderController($settingsRepository, $orderRepository);
+
+        $response = $controller->handleFulfillmentCallback($request);
+
+        $this->assertEquals(200, $response->get_status());
+    }
+
+    public function test_the_fulfillment_callback_returns_404_if_the_order_cannot_be_found()
+    {
+        /** @var \WP_REST_Request|MockInterface */
+        $request = Mockery::mock(\WP_REST_Request::class);
+        $request->allows('get_params')->andReturn(['id' => 12]);
+        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+
+        /** @var SettingsRepository|MockInterface */
+        $settingsRepository = Mockery::mock(SettingsRepository::class);
+
+        /** @var MockInterface|OrderRepository */
+        $orderRepository = Mockery::mock(OrderRepository::class);
+        $orderRepository->allows([
+            "findById" => null
+        ]);
+
+        $controller = new OrderController($settingsRepository, $orderRepository);
+
+        $response = $controller->handleFulfillmentCallback($request);
+
+        $this->assertEquals(404, $response->get_status());
     }
 }

--- a/tests/Integration/OrderControllerTest.php
+++ b/tests/Integration/OrderControllerTest.php
@@ -23,7 +23,7 @@ class OrderControllerTest extends TestCase
         /** @var \WP_REST_Request|MockInterface */
         $request = Mockery::mock(\WP_REST_Request::class);
         $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"order_id": 12}');
+        $request->allows('get_body')->andReturn('{"orderId": 12}');
 
         /** @var MockInterface|OrderRepository */
         $orderRepository = Mockery::mock(OrderRepository::class);
@@ -64,7 +64,7 @@ class OrderControllerTest extends TestCase
         /** @var \WP_REST_Request|MockInterface */
         $request = Mockery::mock(\WP_REST_Request::class);
         $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+        $request->allows('get_body')->andReturn('{"orderId": 12, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
 
         $controller = new OrderController($settingsRepository, $orderRepository);
 
@@ -97,13 +97,13 @@ class OrderControllerTest extends TestCase
         /** @var \WP_REST_Request|MockInterface */
         $request = Mockery::mock(\WP_REST_Request::class);
         $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"order_id": 13, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+        $request->allows('get_body')->andReturn('{"orderId": 1234567890, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
 
         $controller = new OrderController($settingsRepository, $orderRepository);
 
         $controller->handleSuccessCallback($request);
 
-        $order->shouldHaveReceived("update_meta_data")->with("order_id", 13);
+        $order->shouldHaveReceived("update_meta_data", ["order_id", 1234567890]);
         $order->shouldHaveReceived("save");
     }
 
@@ -112,7 +112,7 @@ class OrderControllerTest extends TestCase
         /** @var \WP_REST_Request|MockInterface */
         $request = Mockery::mock(\WP_REST_Request::class);
         $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+        $request->allows('get_body')->andReturn('{"orderId": 1234567890, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
 
         /** @var SettingsRepository|MockInterface */
         $settingsRepository = Mockery::mock(SettingsRepository::class);
@@ -139,7 +139,7 @@ class OrderControllerTest extends TestCase
 
         $controller->handleFulfillmentCallback($request);
 
-        $order->shouldHaveReceived("set_status")->with("wc-fulfilled");
+        $order->shouldHaveReceived("set_status", ["wc-fulfilled"]);
         $order->shouldHaveReceived('save');
     }
 
@@ -148,7 +148,7 @@ class OrderControllerTest extends TestCase
         /** @var \WP_REST_Request|MockInterface */
         $request = Mockery::mock(\WP_REST_Request::class);
         $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+        $request->allows('get_body')->andReturn('{"orderId": 1234567890, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
 
         /** @var SettingsRepository|MockInterface */
         $settingsRepository = Mockery::mock(SettingsRepository::class);
@@ -175,8 +175,8 @@ class OrderControllerTest extends TestCase
 
         $controller->handleFulfillmentCallback($request);
 
-        $order->shouldHaveReceived("update_meta_data")->with("tracking_id", "http://example.com");
-        $order->shouldHaveReceived("update_meta_data")->with("carrier_information", "DHL");
+        $order->shouldHaveReceived("update_meta_data", ["tracking_id", "http://example.com"]);
+        $order->shouldHaveReceived("update_meta_data", ["carrier_information", "DHL"]);
     }
 
     public function test_the_fulfillment_callback_returns_200_on_success()
@@ -184,7 +184,7 @@ class OrderControllerTest extends TestCase
         /** @var \WP_REST_Request|MockInterface */
         $request = Mockery::mock(\WP_REST_Request::class);
         $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+        $request->allows('get_body')->andReturn('{"orderId": 1234567890, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
 
         /** @var SettingsRepository|MockInterface */
         $settingsRepository = Mockery::mock(SettingsRepository::class);

--- a/tests/Integration/PluginInstallationTest.php
+++ b/tests/Integration/PluginInstallationTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Integration;
 
+use Towa\GebruederWeissWooCommerce\Options\Option;
+use Towa\GebruederWeissWooCommerce\Options\OrderOptionsTab;
 use Towa\GebruederWeissWooCommerce\Plugin;
 
 
@@ -31,5 +33,14 @@ class PluginInstallationTest extends \WP_UnitTestCase
         Plugin::onActivation();
 
         $this->assertSame(Plugin::CRON_EVERY_FIVE_MINUTES, \wp_get_schedule(Plugin::RETRY_REQUESTS_CRON_JOB));
+    }
+
+    public function test_it_sets_the_default_values_for_order_options()
+    {
+        Plugin::onActivation();
+
+        $this->assertSame(OrderOptionsTab::ORDER_ID_FIELD_DEFAULT_VALUE, \get_option(Option::OPTIONS_PREFIX . OrderOptionsTab::ORDER_ID_FIELD_NAME));
+        $this->assertSame(OrderOptionsTab::TRACKING_LINK_FIELD_DEFAULT_VALUE, \get_option(Option::OPTIONS_PREFIX . OrderOptionsTab::TRACKING_LINK_FIELD_NAME));
+        $this->assertSame(OrderOptionsTab::CARRIER_INFORMATION_FIELD_DEFAULT_VALUE, \get_option(Option::OPTIONS_PREFIX . OrderOptionsTab::CARRIER_INFORMATION_FIELD_NAME));
     }
 }

--- a/tests/Integration/PluginPageTest.php
+++ b/tests/Integration/PluginPageTest.php
@@ -43,7 +43,7 @@ class PluginPageTest extends \WP_UnitTestCase
 
     public function test_if_page_renders()
     {
-        $optionsPage = (new OptionPage('test', Plugin::OPTIONPAGESLUG));
+        $optionsPage = (new OptionPage('test', Plugin::OPTION_PAGE_SLUG));
 
         \ob_start();
         $optionsPage->render();

--- a/tests/Integration/SettingsRepositoryTest.php
+++ b/tests/Integration/SettingsRepositoryTest.php
@@ -108,4 +108,31 @@ class SettingsRepositoryTest extends \WP_UnitTestCase
 
         $this->assertSame(42, $settingsRepository->getCustomerId());
     }
+
+    public function test_it_can_retrieve_the_order_id_field()
+    {
+        update_option("gbw_order_id_field", "asdf");
+
+        $settingsRepository = new SettingsRepository();
+
+        $this->assertSame("asdf", $settingsRepository->getOrderIdFieldName());
+    }
+
+    public function test_it_can_retrieve_the_tracking_link_field()
+    {
+        update_option("gbw_tracking_link_field", "tracking_link");
+
+        $settingsRepository = new SettingsRepository();
+
+        $this->assertSame("tracking_link", $settingsRepository->getTrackingLinkFieldName());
+    }
+
+    public function test_it_can_retrieve_the_carrier_information()
+    {
+        update_option("gbw_carrier_information_field", "carrier_information");
+
+        $settingsRepository = new SettingsRepository();
+
+        $this->assertSame("carrier_information", $settingsRepository->getCarrierInformationFieldName());
+    }
 }

--- a/tests/Integration/WordpressTest.php
+++ b/tests/Integration/WordpressTest.php
@@ -68,4 +68,12 @@ class WordPressTest extends \WP_UnitTestCase
 
         $this->assertFalse(\wp_get_schedule("hook"));
     }
+
+    public function test_it_can_retrieve_all_meta_keys_for_a_post_type()
+    {
+        $postId = $this->factory()->post->create(["post_type" => "post"]);
+        \update_post_meta($postId, "key1", "value1");
+
+        $this->assertCount(1, WordPress::getAllMetaKeysForPostType("post"));
+    }
 }

--- a/tests/Unit/CreateLogisticsOrderCommandTest.php
+++ b/tests/Unit/CreateLogisticsOrderCommandTest.php
@@ -9,7 +9,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Towa\GebruederWeissSDK\ApiException;
 use Towa\GebruederWeissSDK\Api\DefaultApi;
-use Towa\GebruederWeissSDK\Model\InlineObject;
+use Towa\GebruederWeissSDK\Model\InlineObject as CreateLogisticsOrderPayload;
 use Towa\GebruederWeissSDK\Model\LogisticsOrder;
 use Towa\GebruederWeissWooCommerce\LogisticsOrderFactory;
 use Towa\GebruederWeissWooCommerce\CreateLogisticsOrderCommand;
@@ -40,7 +40,7 @@ class CreateLogisticsOrderCommandTest extends TestCase
         /** @var MockInterface|LogisticsOrderFactory */
         $this->logisticsOrderFactory = Mockery::mock(LogisticsOrderFactory::class);
         $this->logisticsOrderFactory->allows([
-            "buildFromWooCommerceOrder" => new InlineObject(),
+            "buildFromWooCommerceOrder" => new CreateLogisticsOrderPayload(),
         ]);
 
         /** @var MockInterface|stdClass */

--- a/tests/Unit/LogisticsOrderFactoryTest.php
+++ b/tests/Unit/LogisticsOrderFactoryTest.php
@@ -82,35 +82,42 @@ class LogisticsOrderFactoryTest extends TestCase
         ];
     }
 
-    public function test_it_adds_the_callback_url_to_the_logistics_order()
+    public function test_it_adds_the_success_callback_url_to_the_payload()
     {
         $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
 
-        $this->assertSame("http://test.com/wp-json/gebrueder-weiss-woocommerce/v1/update/12", $logisticsOrder->getUrl());
+        $this->assertSame("http://test.com/wp-json/gebrueder-weiss-woocommerce/v1/orders/12/callbacks/success", $logisticsOrder->getCallbacks()->getSuccessCallback());
+    }
+
+    public function test_it_adds_the_fulfillment_callback_url_to_the_payload()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $this->assertSame("http://test.com/wp-json/gebrueder-weiss-woocommerce/v1/orders/12/callbacks/fulfilled", $logisticsOrder->getCallbacks()->getFullfilledCallback());
     }
 
     public function test_it_adds_the_created_date_to_the_logistics_order()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
 
         $this->assertSame("2021-07-29T14:53:52+00:00", $logisticsOrder->getCreationDateTime()->format(DateTimeInterface::RFC3339));
     }
 
     public function test_it_adds_the_owner_id_to_the_logistics_order()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
 
-        $this->assertSame(420000, $logisticsOrder->getOwnerId());
+        $this->assertSame(420000, $logisticsOrder->getCustomerId());
     }
 
     public function test_it_correctly_adds_the_consignee_address()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
 
         $logisticsOrder->getLogisticsAddresses();
         $address = $logisticsOrder->getLogisticsAddresses()[0];
 
-        $this->assertSame("consignee", $address->getAddressType());
+        $this->assertSame("CONSIGNEE", $address->getAddressType());
         $this->assertSame("first-name", $address->getAddress()->getName1());
         $this->assertSame("last-name", $address->getAddress()->getName2());
         $this->assertSame("company", $address->getAddress()->getName3());
@@ -124,7 +131,7 @@ class LogisticsOrderFactoryTest extends TestCase
 
     public function test_it_correctly_adds_the_consignee_contact()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
 
         $logisticsOrder->getLogisticsAddresses();
         $address = $logisticsOrder->getLogisticsAddresses()[0];
@@ -139,7 +146,7 @@ class LogisticsOrderFactoryTest extends TestCase
         $orderMethods = $this->wooCommerceOrderMockMethods;
         $orderMethods["get_shipping_first_name"] = null;
 
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder($orderMethods));
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder($orderMethods))->getLogisticsOrder();
 
         $logisticsOrder->getLogisticsAddresses();
         $address = $logisticsOrder->getLogisticsAddresses()[0];
@@ -149,17 +156,17 @@ class LogisticsOrderFactoryTest extends TestCase
 
     public function test_it_correctly_adds_the_orderby_address()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
 
         $logisticsOrder->getLogisticsAddresses();
         $address = $logisticsOrder->getLogisticsAddresses()[1];
 
-        $this->assertSame("orderby", $address->getAddressType());
+        $this->assertSame("ORDERBY", $address->getAddressType());
     }
 
     public function test_it_adds_the_correct_qualifier_to_the_orderby_address()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
 
         $logisticsOrder->getLogisticsAddresses();
         $address = $logisticsOrder->getLogisticsAddresses()[1];
@@ -169,64 +176,55 @@ class LogisticsOrderFactoryTest extends TestCase
 
     public function test_it_adds_the_custom_id_to_the_orderby_address()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
 
         $logisticsOrder->getLogisticsAddresses();
         $address = $logisticsOrder->getLogisticsAddresses()[1];
 
-        $this->assertSame("gwcustomerid", $address->getAddressReferences()[0]->getQualifier());
+        $this->assertSame("CUSTOMER_ID", $address->getAddressReferences()[0]->getQualifier());
     }
 
     public function test_it_builds_an_order_line_for_each_article()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
 
         $this->assertCount(2, $logisticsOrder->getOrderLines());
     }
 
     public function test_it_ensures_that_the_order_line_array_has_proper_keys()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
 
         $this->assertArrayHasKey(0, $logisticsOrder->getOrderLines());
         $this->assertArrayHasKey(1, $logisticsOrder->getOrderLines());
     }
 
-    public function test_it_adds_one_item_per_orderline()
-    {
-        $order = $this->createMockOrder();
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($order);
-
-        $order->shouldHaveReceived("get_items", ["line_item"]);
-        $this->assertCount(1, $logisticsOrder->getOrderLines()[0]->getArticles());
-    }
-
     public function test_it_converts_woocommerce_order_items_into_articles()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
-        $article = $logisticsOrder->getOrderLines()[0]->getArticles()[0];
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
+        $orderLine = $logisticsOrder->getOrderLines()[0];
 
-        $this->assertSame(234, $article->getArticleId());
-        $this->assertSame(123, $article->getLineItemNumber());
-        $this->assertSame(4, $article->getQuantity());
+        $this->assertSame(234, $orderLine->getArticleId());
+        $this->assertSame(123, $orderLine->getLineItemNumber());
+        $this->assertSame(4, $orderLine->getQuantity());
     }
 
     public function test_it_adds_one_delivery_note_to_the_article()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
-        $article = $logisticsOrder->getOrderLines()[0]->getArticles()[0];
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
+        $article = $logisticsOrder->getOrderLines()[0];
 
-        $this->assertCount(1, $article->getLogisticsrequirement()->getNotes());
-        $this->assertSame("deliverynotearticle", $article->getLogisticsrequirement()->getNotes()[0]->getNoteType());
+        $this->assertCount(1, $article->getNotes());
+        $this->assertSame("DELIVERYNOTE", $article->getNotes()[0]->getNoteType());
     }
 
     public function test_it_adds_the_customer_message_to_the_delivery_note()
     {
-        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
-        $article = $logisticsOrder->getOrderLines()[0]->getArticles()[0];
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
+        $article = $logisticsOrder->getOrderLines()[0];
 
-        $this->assertSame("de-DE", $article->getLogisticsrequirement()->getNotes()[0]->getNoteText()->getLanguage());
-        $this->assertSame("note", $article->getLogisticsrequirement()->getNotes()[0]->getNoteText()->getText());
+        $this->assertSame("de-DE", $article->getNotes()[0]->getNoteText()->getLanguage());
+        $this->assertSame("note", $article->getNotes()[0]->getNoteText()->getText());
     }
 
     private function createMockOrder(?array $mockMethods = null)

--- a/tests/Unit/LogisticsOrderFactoryTest.php
+++ b/tests/Unit/LogisticsOrderFactoryTest.php
@@ -223,7 +223,7 @@ class LogisticsOrderFactoryTest extends TestCase
         $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
         $article = $logisticsOrder->getOrderLines()[0];
 
-        $this->assertSame("de-DE", $article->getNotes()[0]->getNoteText()->getLanguage());
+        $this->assertSame("en-US", $article->getNotes()[0]->getNoteText()->getLanguage());
         $this->assertSame("note", $article->getNotes()[0]->getNoteText()->getText());
     }
 

--- a/tests/Unit/LogisticsOrderFactoryTest.php
+++ b/tests/Unit/LogisticsOrderFactoryTest.php
@@ -93,7 +93,7 @@ class LogisticsOrderFactoryTest extends TestCase
     {
         $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
 
-        $this->assertSame("http://test.com/wp-json/gebrueder-weiss-woocommerce/v1/orders/12/callbacks/fulfilled", $logisticsOrder->getCallbacks()->getFullfilledCallback());
+        $this->assertSame("http://test.com/wp-json/gebrueder-weiss-woocommerce/v1/orders/12/callbacks/fulfillment", $logisticsOrder->getCallbacks()->getFullfilledCallback());
     }
 
     public function test_it_adds_the_created_date_to_the_logistics_order()

--- a/tests/Unit/RetryFailedRequestQueueWorkerTest.php
+++ b/tests/Unit/RetryFailedRequestQueueWorkerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Towa\GebruederWeissSDK\ApiException;
 use Towa\GebruederWeissSDK\Configuration;
 use Towa\GebruederWeissSDK\Api\DefaultApi;
-use Towa\GebruederWeissSDK\Model\InlineObject;
+use Towa\GebruederWeissSDK\Model\InlineObject as CreateLogisticsOrderPayload;
 use Towa\GebruederWeissSDK\Model\LogisticsOrder;
 use Towa\GebruederWeissWooCommerce\FailedRequestQueue\FailedRequest;
 use Towa\GebruederWeissWooCommerce\FailedRequestQueue\FailedRequestRepository;
@@ -48,7 +48,7 @@ class RetryFailedRequestsQueueWorkerTest extends TestCase
         /** @var MockInterface|LogisticsOrderFactory */
         $this->logisticsOrderFactory = Mockery::mock(LogisticsOrderFactory::class);
         $this->logisticsOrderFactory->allows([
-            "buildFromWooCommerceOrder" => new InlineObject(),
+            "buildFromWooCommerceOrder" => new CreateLogisticsOrderPayload(),
         ]);
 
         /** @var MockInterface|\WC_Order */

--- a/tests/Unit/WooCommerceOrderStatusChangedTest.php
+++ b/tests/Unit/WooCommerceOrderStatusChangedTest.php
@@ -104,7 +104,7 @@ class WooCommerceOrderStatusChangedTest extends TestCase
 
         $this->plugin->wooCommerceOrderStatusChanged(21, "from-state", self::SELECTED_FULFILLMENT_STATE, $order);
 
-        $this->gebruederWeissApi->shouldHaveReceived("logisticsOrderPost", ["de-DE", CreateLogisticsOrderPayload::class]);
+        $this->gebruederWeissApi->shouldHaveReceived("logisticsOrderPost", ["en-US", CreateLogisticsOrderPayload::class]);
     }
 
     public function test_it_creates_a_failed_request_if_the_command_fails()

--- a/tests/Unit/WooCommerceOrderStatusChangedTest.php
+++ b/tests/Unit/WooCommerceOrderStatusChangedTest.php
@@ -14,7 +14,7 @@ use Mockery\MockInterface;
 use Towa\GebruederWeissSDK\Api\DefaultApi;
 use Towa\GebruederWeissSDK\ApiException;
 use Towa\GebruederWeissSDK\Configuration;
-use Towa\GebruederWeissSDK\Model\InlineObject;
+use Towa\GebruederWeissSDK\Model\InlineObject as CreateLogisticsOrderPayload;
 use Towa\GebruederWeissSDK\Model\LogisticsOrder;
 use Towa\GebruederWeissWooCommerce\Support\WordPress;
 use Towa\GebruederWeissWooCommerce\OAuth\OAuthToken;
@@ -70,7 +70,7 @@ class WooCommerceOrderStatusChangedTest extends TestCase
         /** @var MockInterface|LogisticsOrderFactory */
         $this->logisticsOrderFactory = Mockery::mock(LogisticsOrderFactory::class);
         $this->logisticsOrderFactory->allows([
-            "buildFromWooCommerceOrder" => new InlineObject(),
+            "buildFromWooCommerceOrder" => new CreateLogisticsOrderPayload(),
         ]);
 
         /** @var MockInterface|OAuthAuthenticator */
@@ -104,7 +104,7 @@ class WooCommerceOrderStatusChangedTest extends TestCase
 
         $this->plugin->wooCommerceOrderStatusChanged(21, "from-state", self::SELECTED_FULFILLMENT_STATE, $order);
 
-        $this->gebruederWeissApi->shouldHaveReceived("logisticsOrderPost", ["de-DE", InlineObject::class]);
+        $this->gebruederWeissApi->shouldHaveReceived("logisticsOrderPost", ["de-DE", CreateLogisticsOrderPayload::class]);
     }
 
     public function test_it_creates_a_failed_request_if_the_command_fails()

--- a/tests/Unit/WooCommerceOrderStatusChangedTest.php
+++ b/tests/Unit/WooCommerceOrderStatusChangedTest.php
@@ -11,9 +11,10 @@ use PHPUnit\Framework\TestCase;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
-use Towa\GebruederWeissSDK\Api\WriteApi;
+use Towa\GebruederWeissSDK\Api\DefaultApi;
 use Towa\GebruederWeissSDK\ApiException;
 use Towa\GebruederWeissSDK\Configuration;
+use Towa\GebruederWeissSDK\Model\InlineObject;
 use Towa\GebruederWeissSDK\Model\LogisticsOrder;
 use Towa\GebruederWeissWooCommerce\Support\WordPress;
 use Towa\GebruederWeissWooCommerce\OAuth\OAuthToken;
@@ -28,8 +29,8 @@ class WooCommerceOrderStatusChangedTest extends TestCase
     /** @var Plugin */
     private $plugin;
 
-    /** @var MockInterface|WriteApi */
-    private $writeApi;
+    /** @var MockInterface|DefaultApi */
+    private $gebruederWeissApi;
 
     /** @var MockInterface|SettingsRepository */
     private $settingsRepository;
@@ -50,10 +51,10 @@ class WooCommerceOrderStatusChangedTest extends TestCase
         /** @var Plugin */
         $this->plugin = Plugin::getInstance();
 
-        /** @var MockInterface|WriteApi */
-        $this->writeApi = Mockery::mock(WriteApi::class);
-        $this->writeApi->allows("logisticsOrderPost");
-        $this->writeApi->allows(["getConfig" => new Configuration()]);
+        /** @var MockInterface|DefaultApi */
+        $this->gebruederWeissApi = Mockery::mock(DefaultApi::class);
+        $this->gebruederWeissApi->allows("logisticsOrderPost");
+        $this->gebruederWeissApi->allows(["getConfig" => new Configuration()]);
 
         /** @var MockInterface|SettingsRepository */
         $this->settingsRepository = Mockery::mock(SettingsRepository::class);
@@ -69,7 +70,7 @@ class WooCommerceOrderStatusChangedTest extends TestCase
         /** @var MockInterface|LogisticsOrderFactory */
         $this->logisticsOrderFactory = Mockery::mock(LogisticsOrderFactory::class);
         $this->logisticsOrderFactory->allows([
-            "buildFromWooCommerceOrder" => new LogisticsOrder(),
+            "buildFromWooCommerceOrder" => new InlineObject(),
         ]);
 
         /** @var MockInterface|OAuthAuthenticator */
@@ -80,7 +81,7 @@ class WooCommerceOrderStatusChangedTest extends TestCase
         $this->failedRequestRepository = Mockery::mock(FailedRequestRepository::class);
         $this->failedRequestRepository->allows("create");
 
-        $this->plugin->setWriteApiClient($this->writeApi);
+        $this->plugin->setGebruederWeissApiClient($this->gebruederWeissApi);
         $this->plugin->setSettingsRepository($this->settingsRepository);
         $this->plugin->setAuthenticationClient($this->authenticator);
         $this->plugin->setLogisticsOrderFactory($this->logisticsOrderFactory);
@@ -91,7 +92,7 @@ class WooCommerceOrderStatusChangedTest extends TestCase
     {
         $this->plugin->wooCommerceOrderStatusChanged(21, "from-state", "some-state", (object)[]);
 
-        $this->writeApi->shouldNotHaveBeenCalled(["logisticsOrderPost"]);
+        $this->gebruederWeissApi->shouldNotHaveBeenCalled(["logisticsOrderPost"]);
     }
 
     public function test_it_calls_the_api_if_the_fulfillment_state_matches_the_selection()
@@ -103,16 +104,16 @@ class WooCommerceOrderStatusChangedTest extends TestCase
 
         $this->plugin->wooCommerceOrderStatusChanged(21, "from-state", self::SELECTED_FULFILLMENT_STATE, $order);
 
-        $this->writeApi->shouldHaveReceived("logisticsOrderPost", [LogisticsOrder::class]);
+        $this->gebruederWeissApi->shouldHaveReceived("logisticsOrderPost", ["de-DE", InlineObject::class]);
     }
 
     public function test_it_creates_a_failed_request_if_the_command_fails()
     {
-        /** @var MockInterface|WriteApi */
-        $writeApi = Mockery::mock(WriteApi::class);
-        $writeApi->allows(["getConfig" => new Configuration()]);
-        $writeApi->shouldReceive("logisticsOrderPost")->andThrow(new ApiException("Unauthenticated", 401));
-        $this->plugin->setWriteApiClient($writeApi);
+        /** @var MockInterface|DefaultApi */
+        $gebruederWeissApi = Mockery::mock(DefaultApi::class);
+        $gebruederWeissApi->allows(["getConfig" => new Configuration()]);
+        $gebruederWeissApi->shouldReceive("logisticsOrderPost")->andThrow(new ApiException("Unauthenticated", 401));
+        $this->plugin->setGebruederWeissApiClient($gebruederWeissApi);
 
         /** @var MockInterface|object */
         $order = Mockery::mock("WC_Order");
@@ -140,11 +141,11 @@ class WooCommerceOrderStatusChangedTest extends TestCase
         $wordpressMock = Mockery::mock("alias:" . WordPress::class);
         $wordpressMock->shouldReceive("sendMailToAdmin")->once();
 
-        /** @var MockInterface|WriteApi */
-        $writeApi = Mockery::mock(WriteApi::class);
-        $writeApi->allows(["getConfig" => new Configuration()]);
-        $writeApi->shouldReceive("logisticsOrderPost")->andThrow(new ApiException("Conflict", 409));
-        $this->plugin->setWriteApiClient($writeApi);
+        /** @var MockInterface|DefaultApi */
+        $gebruederWeissApi = Mockery::mock(DefaultApi::class);
+        $gebruederWeissApi->allows(["getConfig" => new Configuration()]);
+        $gebruederWeissApi->shouldReceive("logisticsOrderPost")->andThrow(new ApiException("Conflict", 409));
+        $this->plugin->setGebruederWeissApiClient($gebruederWeissApi);
 
         /** @var MockInterface|SettingsRepository */
         $settingsRepository = Mockery::mock(SettingsRepository::class);


### PR DESCRIPTION
## TLDR;

- updates the gebrueder weiss sdk
- fixes breaking changes that came in due to changes to the api schema by gebrueder weiss
- handles the success and fullfilled callbacks
- changes the hardcoded language to en-US
- adds an option page for managing the fields in which the order meta data should be stored
- sets default values for these settings during plugin activation