### PR TITLE
Add missing quotes for the attribute value in dropdown

### DIFF
--- a/templates/options/dropdown.twig
+++ b/templates/options/dropdown.twig
@@ -1,6 +1,6 @@
 <select name="{{ option.slug }}">
     <option disabled {{ (option.value is empty) or (option.value not in option.options|keys) ? 'selected': '' }}>Select an option</option>
     {% for value, label in option.options %}
-        <option value={{ value }} {{ (option.value == value) ? 'selected': '' }}>{{ label }}</option>
+        <option value="{{ value }}" {{ (option.value == value) ? 'selected': '' }}>{{ label }}</option>
     {% endfor %}
 </select>


### PR DESCRIPTION
## TLDR;

- Adds the missing quotes to the value attribute in the select. This prevented values with a whitespace in them from beeing selectable.