### PR TITLE
Feature/wcwwp 101 fix differences bettwen mock api and sandbox

### DIFF
--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -71,7 +71,6 @@ class LogisticsOrderFactory
         $logisticsProduct->setProduct("OUTBOUND_DELIVERY");
         $logisticsProduct->setProductServiceLevel("STANDARD");
 
-
         $logisticsRequirements = new LogisticsRequirements();
         $logisticsRequirements->setLogisticsProduct($logisticsProduct);
         $logisticsOrder->setLogisticsRequirements($logisticsRequirements);

--- a/includes/LogisticsOrderFactory.php
+++ b/includes/LogisticsOrderFactory.php
@@ -11,16 +11,14 @@ defined('ABSPATH') || exit;
 
 use Towa\GebruederWeissSDK\Model\Address;
 use Towa\GebruederWeissSDK\Model\AddressReference;
-use Towa\GebruederWeissSDK\Model\Article;
-use Towa\GebruederWeissSDK\Model\ArticleNote;
 use Towa\GebruederWeissSDK\Model\Contact;
 use Towa\GebruederWeissSDK\Model\InlineObject as CreateLogisticsOrderPayload;
 use Towa\GebruederWeissSDK\Model\LingualText;
 use Towa\GebruederWeissSDK\Model\LogisticsAddress;
 use Towa\GebruederWeissSDK\Model\LogisticsOrder;
 use Towa\GebruederWeissSDK\Model\LogisticsOrderCallbacks;
+use Towa\GebruederWeissSDK\Model\LogisticsProduct;
 use Towa\GebruederWeissSDK\Model\LogisticsRequirements;
-use Towa\GebruederWeissSDK\Model\Note;
 use Towa\GebruederWeissSDK\Model\OrderLine;
 use Towa\GebruederWeissSDK\Model\OrderLineNote;
 
@@ -64,6 +62,19 @@ class LogisticsOrderFactory
             $this->createConsigneeAddress($wooCommerceOrder),
             $this->createOrderbyAddress()
         ]);
+
+        $logisticsOrder->setCustomerOrder(strval($wooCommerceOrder->get_id()));
+        // TODO: Replace the dummy warehouse id with the correct warehouse id.
+        $logisticsOrder->setWarehouseId("4000000000");
+
+        $logisticsProduct = new LogisticsProduct();
+        $logisticsProduct->setProduct("OUTBOUND_DELIVERY");
+        $logisticsProduct->setProductServiceLevel("STANDARD");
+
+
+        $logisticsRequirements = new LogisticsRequirements();
+        $logisticsRequirements->setLogisticsProduct($logisticsProduct);
+        $logisticsOrder->setLogisticsRequirements($logisticsRequirements);
 
         $logisticsOrder->setOrderLines(
             $this->createOrderLines($wooCommerceOrder)
@@ -147,7 +158,7 @@ class LogisticsOrderFactory
         return array_map(function (object $orderItem) use ($wooCommerceOrder) {
             $orderLine = new OrderLine();
 
-            $orderLine->setArticleId(intval($orderItem->get_product()->get_sku()));
+            $orderLine->setArticleId(strval($orderItem->get_product()->get_sku()));
             $orderLine->setLineItemNumber($orderItem->get_id());
             $orderLine->setQuantity($orderItem->get_quantity());
 

--- a/includes/OAuth/OAuthAuthenticator.php
+++ b/includes/OAuth/OAuthAuthenticator.php
@@ -61,6 +61,7 @@ class OAuthAuthenticator
             $leagueToken = $this->authProvider->getAccessToken('client_credentials', [
                 'client_id' => $this->settingsRepository->getClientId(),
                 'client_secret' => $this->settingsRepository->getClientSecret(),
+                'scope' => 'API_CUSAPI_LOGISTICS_ORDER_CREATE',
             ]);
 
             return new OAuthToken(

--- a/includes/OAuth/OAuthToken.php
+++ b/includes/OAuth/OAuthToken.php
@@ -79,7 +79,10 @@ class OAuthToken implements Serializable
      */
     public function serialize()
     {
-        return serialize([$this->token, $this->expires]);
+        return json_encode([
+            "token" => $this->token,
+            "expires" => $this->expires,
+        ]);
     }
 
     /**
@@ -90,6 +93,8 @@ class OAuthToken implements Serializable
      */
     public function unserialize($data)
     {
-        list($this->token, $this->expires) = unserialize($data);
+        $deserialized = json_decode($data);
+        $this->token = $deserialized->token;
+        $this->expires = $deserialized->expires;
     }
 }

--- a/tests/Unit/LogisticsOrderFactoryTest.php
+++ b/tests/Unit/LogisticsOrderFactoryTest.php
@@ -82,6 +82,21 @@ class LogisticsOrderFactoryTest extends TestCase
         ];
     }
 
+    public function test_it_adds_the_customer_order_to_the_payload()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        $this->assertSame("12", $logisticsOrder->getLogisticsOrder()->getCustomerOrder());
+    }
+
+    public function test_it_adds_the_warehouse_id_to_the_payload()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
+
+        // TODO: Replace the dummy warehouse id with the correct warehouse id.
+        $this->assertSame("4000000000", $logisticsOrder->getLogisticsOrder()->getWarehouseId());
+    }
+
     public function test_it_adds_the_success_callback_url_to_the_payload()
     {
         $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder());
@@ -204,7 +219,7 @@ class LogisticsOrderFactoryTest extends TestCase
         $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
         $orderLine = $logisticsOrder->getOrderLines()[0];
 
-        $this->assertSame(234, $orderLine->getArticleId());
+        $this->assertSame("234", $orderLine->getArticleId());
         $this->assertSame(123, $orderLine->getLineItemNumber());
         $this->assertSame(4, $orderLine->getQuantity());
     }
@@ -225,6 +240,23 @@ class LogisticsOrderFactoryTest extends TestCase
 
         $this->assertSame("en-US", $article->getNotes()[0]->getNoteText()->getLanguage());
         $this->assertSame("note", $article->getNotes()[0]->getNoteText()->getText());
+    }
+
+    public function test_it_adds_logistics_requirements()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
+        $logisticsRequirement = $logisticsOrder->getLogisticsRequirements();
+
+        $this->assertNotNull($logisticsRequirement->getLogisticsProduct());
+    }
+
+    public function test_it_adds_a_logistics_product()
+    {
+        $logisticsOrder = $this->logisticsOrderFactory->buildFromWooCommerceOrder($this->createMockOrder())->getLogisticsOrder();
+        $product = $logisticsOrder->getLogisticsRequirements()->getLogisticsProduct();
+
+        $this->assertSame("OUTBOUND_DELIVERY", $product->getProduct());
+        $this->assertSame("STANDARD", $product->getProductServiceLevel());
     }
 
     private function createMockOrder(?array $mockMethods = null)

--- a/tests/Unit/OAuthTokenTest.php
+++ b/tests/Unit/OAuthTokenTest.php
@@ -37,13 +37,13 @@ class OAuthTokenTest extends TestCase
 
     public function test_it_can_serialize_and_unserialize_the_token()
     {
-        $token = new OAuthToken("test", 1628168570);
+        $token = new OAuthToken("test-1", 1628168570);
         $serialized = $token->serialize();
         $newToken = new OAuthToken("", 0);
 
         $newToken->unserialize($serialized);
 
-        $this->assertSame("test", $newToken->getToken());
+        $this->assertSame("test-1", $newToken->getToken());
         $this->assertSame(1628168570 - time(), $newToken->getExpiresIn());
     }
 }


### PR DESCRIPTION
## TLDR;

- adds a scope for the auth token
- changes the serialization method for the auth token, since storing it in the DB messed with the token in the previous method
- adds the customer order field (WooCommerce order id)
- adds a dummy warehouse id
- adds a logistics requirements object with the default values
- fixes incompatible field types