### PR TITLE
Feat/gwdc 35/make trackingurl optional

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -34,9 +34,6 @@ To be able to work with API data without relying on the Gebrüder Weiss APIs, th
 ## Sandbox API
 
 Gebrueder Weiss provides a sandbox API for testing and development.
-Credentials for this API can be created via the link stored in the "Gebrüder Weiss API Developer" entry in SEC.
-In the API Credentials tab, there is a section "View Credentials".
-All currently existing apps are listed in this section, and you can also view their credentials.
 
 ## Wp cli
 

--- a/includes/FailedRequestQueue/FailedRequestRepository.php
+++ b/includes/FailedRequestQueue/FailedRequestRepository.php
@@ -26,13 +26,13 @@ class FailedRequestRepository
         global $wpdb;
 
         $statement = $wpdb->prepare(
-            "SELECT * FROM {$wpdb->prefix}gbw_request_retry_queue
+            "SELECT * FROM {$wpdb->base_prefix}gbw_request_retry_queue
              WHERE
-                status = \"%s\" AND
+                status = '%s' AND
                 failed_attempts < %d AND
-                last_attempt_date < CURRENT_TIME - INTERVAL 5 MINUTE
+                last_attempt_date < ('%s' - INTERVAL 5 MINUTE)
              LIMIT 1",
-            [FailedRequest::FAILED_STATUS, FailedRequest::MAX_ATTEMPTS]
+            [FailedRequest::FAILED_STATUS, FailedRequest::MAX_ATTEMPTS, (new DateTime())->format('Y-m-d H:i:s')]
         );
 
         $row = $wpdb->get_row($statement);
@@ -64,7 +64,7 @@ class FailedRequestRepository
 
         $lastAttemptedDate = $lastAttemptedDate ?? new DateTime();
 
-        $statement = $wpdb->prepare("INSERT INTO {$wpdb->prefix}gbw_request_retry_queue (order_id, status, failed_attempts, last_attempt_date) VALUES (%d, \"%s\", %d, \"%s\")", [$orderId, $status, $failedAttempts, $lastAttemptedDate->format("Y-m-d H:i:s")]);
+        $statement = $wpdb->prepare("INSERT INTO {$wpdb->base_prefix}gbw_request_retry_queue (order_id, status, failed_attempts, last_attempt_date) VALUES (%d, \"%s\", %d, \"%s\")", [$orderId, $status, $failedAttempts, $lastAttemptedDate->format("Y-m-d H:i:s")]);
         $wpdb->query($statement);
 
         $failedRequest = new FailedRequest(
@@ -103,7 +103,7 @@ class FailedRequestRepository
         $whereFormat = [ "%d" ];
 
         $wpdb->update(
-            "{$wpdb->prefix}gbw_request_retry_queue",
+            "{$wpdb->base_prefix}gbw_request_retry_queue",
             $data,
             $where,
             $format,
@@ -122,7 +122,7 @@ class FailedRequestRepository
     {
         global $wpdb;
 
-        $statement = $wpdb->prepare("DELETE FROM {$wpdb->prefix}gbw_request_retry_queue WHERE status = \"%s\" OR failed_attempts >= %d", [FailedRequest::SUCCESS_STATUS, FailedRequest::MAX_ATTEMPTS]);
+        $statement = $wpdb->prepare("DELETE FROM {$wpdb->base_prefix}gbw_request_retry_queue WHERE status = \"%s\" OR failed_attempts >= %d", [FailedRequest::SUCCESS_STATUS, FailedRequest::MAX_ATTEMPTS]);
         $wpdb->get_results($statement);
     }
 }

--- a/includes/SettingsRepository.php
+++ b/includes/SettingsRepository.php
@@ -132,7 +132,7 @@ class SettingsRepository
     /**
      * Reads the custom field name for the tracking link from the plugin settings.
      *
-     * @return integer|null
+     * @return string
      */
     public function getTrackingLinkFieldName(): string
     {
@@ -142,7 +142,7 @@ class SettingsRepository
     /**
      * Reads the custom field name for the carrier information from the plugin settings.
      *
-     * @return integer|null
+     * @return string
      */
     public function getCarrierInformationFieldName(): string
     {

--- a/tests/Integration/FailedRequestRepositoryTest.php
+++ b/tests/Integration/FailedRequestRepositoryTest.php
@@ -15,6 +15,12 @@ class FailedRequestRepositoryTest extends \WP_UnitTestCase
         Plugin::onActivation();
     }
 
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Plugin::onUninstall();
+    }
+
     public function test_it_can_create_a_failed_request()
     {
         global $wpdb;
@@ -23,7 +29,7 @@ class FailedRequestRepositoryTest extends \WP_UnitTestCase
 
         $request = $repository->create(12, FailedRequest::FAILED_STATUS, 2);
 
-        $numberOfRows = $wpdb->get_var("SELECT count(*) FROM {$wpdb->prefix}gbw_request_retry_queue WHERE order_id = {$request->getOrderId()} AND status = \"{$request->getStatus()}\" AND failed_attempts = {$request->getFailedAttempts()}");
+        $numberOfRows = $wpdb->get_var("SELECT count(*) FROM {$wpdb->base_prefix}gbw_request_retry_queue WHERE order_id = {$request->getOrderId()} AND status = \"{$request->getStatus()}\" AND failed_attempts = {$request->getFailedAttempts()}");
         $this->assertSame(1, intval($numberOfRows));
     }
 
@@ -81,7 +87,7 @@ class FailedRequestRepositoryTest extends \WP_UnitTestCase
     public function test_it_does_not_return_requests_that_have_been_retried_less_then_five_minutes_ago()
     {
         $repository = new FailedRequestRepository();
-        $repository->create(12, FailedRequest::FAILED_STATUS, FailedRequest::MAX_ATTEMPTS - 1, new DateTime());
+        $repository->create(12, FailedRequest::FAILED_STATUS, FailedRequest::MAX_ATTEMPTS - 1);
 
         $request = $repository->findOneToRetry();
 
@@ -102,7 +108,7 @@ class FailedRequestRepositoryTest extends \WP_UnitTestCase
     {
         global $wpdb;
 
-        $numberOfRows = $wpdb->get_var("SELECT count(*) FROM {$wpdb->prefix}gbw_request_retry_queue");
+        $numberOfRows = $wpdb->get_var("SELECT count(*) FROM {$wpdb->base_prefix}gbw_request_retry_queue");
 
         return intval($numberOfRows);
     }
@@ -111,6 +117,6 @@ class FailedRequestRepositoryTest extends \WP_UnitTestCase
     {
         global $wpdb;
 
-        return $wpdb->get_row("SELECT * FROM {$wpdb->prefix}gbw_request_retry_queue LIMIT 1");
+        return $wpdb->get_row("SELECT * FROM {$wpdb->base_prefix}gbw_request_retry_queue LIMIT 1");
     }
 }

--- a/tests/Integration/OrderControllerTest.php
+++ b/tests/Integration/OrderControllerTest.php
@@ -78,10 +78,9 @@ class OrderControllerTest extends TestCase
                 'getOrderIdFieldName' => 'order_id'
             ]);
 
-        self::$order
-            ->allows('get_status')
-            ->allows('update_meta_data')
-            ->allows('save');
+        self::$order->allows('get_status');
+        self::$order->allows('update_meta_data');
+        self::$order->allows('save');
 
         self::$orderRepository
             ->allows(['findById' => self::$order]);
@@ -101,19 +100,17 @@ class OrderControllerTest extends TestCase
                 'getOrderIdFieldName' => 'order_id'
             ]);
 
-        self::$order
-            ->allows('get_status')
-            ->allows('update_meta_data')
-            ->allows('save');
+        self::$order->allows('get_status');
+        self::$order->allows('update_meta_data');
+        self::$order->allows('save');
 
         self::$orderRepository
             ->allows(['findById' => self::$order]);
 
         self::successCallback();
 
-        self::$order
-            ->shouldHaveReceived('update_meta_data', ['order_id', 1234567890])
-            ->shouldHaveReceived('save');
+        self::$order->shouldHaveReceived('update_meta_data', ['order_id', 1234567890]);
+        self::$order->shouldHaveReceived('save');
     }
 
 
@@ -136,20 +133,18 @@ class OrderControllerTest extends TestCase
                 'getCarrierInformationFieldName' => 'carrier_information'
             ]);
 
-        self::$order
-            ->allows('set_status')
-            ->allows('get_status')
-            ->allows('update_meta_data')
-            ->allows('save');
+        self::$order->allows('set_status');
+        self::$order->allows('get_status');
+        self::$order->allows('update_meta_data');
+        self::$order->allows('save');
 
         self::$orderRepository
             ->allows(['findById' => self::$order]);
 
         self::fulfillmentCallback();
 
-        self::$order
-            ->shouldHaveReceived('set_status', ['wc-fulfilled'])
-            ->shouldHaveReceived('save');
+        self::$order->shouldHaveReceived('set_status', ['wc-fulfilled']);
+        self::$order->shouldHaveReceived('save');
     }
 
     public function test_the_fulfillment_callback_updates_the_order_meta_data(): void
@@ -171,20 +166,18 @@ class OrderControllerTest extends TestCase
                 'getCarrierInformationFieldName' => 'carrier_information'
             ]);
 
-        self::$order
-            ->allows('set_status')
-            ->allows('get_status')
-            ->allows('update_meta_data')
-            ->allows('save');
+        self::$order->allows('set_status');
+        self::$order->allows('get_status');
+        self::$order->allows('update_meta_data');
+        self::$order->allows('save');
 
         self::$orderRepository
             ->allows(['findById' => self::$order]);
 
         self::fulfillmentCallback();
 
-        self::$order
-            ->shouldHaveReceived('update_meta_data', ['tracking_id', 'http://example.com'])
-            ->shouldHaveReceived('update_meta_data', ['carrier_information', 'DHL']);
+        self::$order->shouldHaveReceived('update_meta_data', ['tracking_id', 'http://example.com']);
+        self::$order->shouldHaveReceived('update_meta_data', ['carrier_information', 'DHL']);
     }
 
 
@@ -207,20 +200,18 @@ class OrderControllerTest extends TestCase
                 'getCarrierInformationFieldName' => 'carrier_information'
             ]);
 
-        self::$order
-            ->allows('set_status')
-            ->allows('get_status')
-            ->allows('update_meta_data')
-            ->allows('save');
+            self::$order->allows('set_status');
+            self::$order->allows('get_status');
+            self::$order->allows('update_meta_data');
+            self::$order->allows('save');
 
         self::$orderRepository
             ->allows(['findById' => self::$order]);
 
         self::fulfillmentCallback();
 
-        self::$order
-            ->shouldNotHaveReceived('update_meta_data', ['tracking_id', ''])
-            ->shouldHaveReceived('update_meta_data', ['carrier_information', 'DHL']);
+        self::$order->shouldNotHaveReceived('update_meta_data', ['tracking_id', '']);
+        self::$order->shouldHaveReceived('update_meta_data', ['carrier_information', 'DHL']);
     }
 
 
@@ -243,11 +234,10 @@ class OrderControllerTest extends TestCase
                 'getCarrierInformationFieldName' => 'carrier_information'
             ]);
 
-        self::$order
-            ->allows('set_status')
-            ->allows('get_status')
-            ->allows('update_meta_data')
-            ->allows('save');
+        self::$order->allows('set_status');
+        self::$order->allows('get_status');
+        self::$order->allows('update_meta_data');
+        self::$order->allows('save');
 
         self::$orderRepository
             ->allows(['findById' => self::$order]);
@@ -268,8 +258,7 @@ class OrderControllerTest extends TestCase
                 ])
             );
 
-        self::$orderRepository
-            ->allows(['findById' => null]);
+        self::$orderRepository->allows(['findById' => null]);
 
         $this->assertEquals(404, self::fulfillmentCallback()->get_status());
     }

--- a/tests/Integration/OrderControllerTest.php
+++ b/tests/Integration/OrderControllerTest.php
@@ -39,6 +39,7 @@ class OrderControllerTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         self::$settingsRepository = Mockery::mock(SettingsRepository::class);
         self::$request            = Mockery::mock(WP_REST_Request::class);
         self::$orderRepository    = Mockery::mock(OrderRepository::class);

--- a/tests/Integration/OrderControllerTest.php
+++ b/tests/Integration/OrderControllerTest.php
@@ -9,231 +9,280 @@ use Mockery\MockInterface;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Towa\GebruederWeissWooCommerce\OrderRepository;
+use WC_Order;
+use WP_REST_Request;
+use WP_REST_Response;
 
 class OrderControllerTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    public function test_the_success_callback_returns_a_404_response_if_no_order_with_the_given_id_exists()
+    /** @var MockInterface|OrderRepository */
+    private static $orderRepository;
+
+    /** @var MockInterface|WP_REST_Request */
+    private static $request;
+
+    /** @var MockInterface|SettingsRepository */
+    private static $settingsRepository;
+
+    /** @var MockInterface|WC_Order */
+    private static $order;
+
+    /** @var OrderController */
+    private static $orderController;
+
+    private const ORDER_ID          = 1;
+    private const NEW_ORDER_ID      = 1234567890;
+    private const TRACKING_URL      = 'http://example.com';
+    private const TRANSPORT_PRODUCT = 'DHL';
+
+    protected function setUp(): void
     {
-        /** @var SettingsRepository|MockInterface */
-        $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows();
+        self::$settingsRepository = Mockery::mock(SettingsRepository::class);
+        self::$request            = Mockery::mock(WP_REST_Request::class);
+        self::$orderRepository    = Mockery::mock(OrderRepository::class);
+        self::$order              = Mockery::mock(WC_Order::class);
+        self::$orderController    = new OrderController(self::$settingsRepository, self::$orderRepository);
 
-        /** @var \WP_REST_Request|MockInterface */
-        $request = Mockery::mock(\WP_REST_Request::class);
-        $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"orderId": 12}');
-
-        /** @var MockInterface|OrderRepository */
-        $orderRepository = Mockery::mock(OrderRepository::class);
-        $orderRepository->allows([
-            "findById" => null
-        ]);
-
-        $controller = new OrderController($settingsRepository, $orderRepository);
-
-
-        $response = $controller->handleSuccessCallback($request);
-
-
-        $this->assertEquals(404, $response->status);
+        self::$request
+            ->allows('get_params')
+            ->andReturn(['id' => self::ORDER_ID]);
     }
 
-    public function test_the_success_callback_returns_a_200_response_if_a_order_with_the_given_id_exists()
+
+    public function test_the_success_callback_returns_a_404_response_if_no_order_with_the_given_id_exists(): void
     {
-        /** @var SettingsRepository|MockInterface */
-        $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows([
-            'getFulfilledState' => 'wc-fulfilled',
-            'getOrderIdFieldName' => 'order_id'
-        ]);
+        self::$request
+            ->allows('get_body')
+            ->andReturn(json_encode(['orderId' => self::ORDER_ID]));
 
-        /** @var MockInterface|\WC_Order */
-        $order = Mockery::mock("WC_Order");
-        $order->allows("get_status");
-        $order->allows("update_meta_data");
-        $order->allows("save");
+        self::$settingsRepository
+            ->allows();
 
-        /** @var MockInterface|OrderRepository */
-        $orderRepository = Mockery::mock(OrderRepository::class);
-        $orderRepository->allows([
-            "findById" => $order
-        ]);
+        self::$orderRepository
+            ->allows(['findById' => null]);
 
-        /** @var \WP_REST_Request|MockInterface */
-        $request = Mockery::mock(\WP_REST_Request::class);
-        $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"orderId": 12, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
-
-        $controller = new OrderController($settingsRepository, $orderRepository);
-
-        $response = $controller->handleSuccessCallback($request);
-
-        $this->assertEquals(200, $response->status);
+        $this->assertEquals(404, self::successCallback()->get_status());
     }
 
-    public function test_the_success_callback_updates_the_order_id()
+    public function test_the_success_callback_returns_a_200_response_if_a_order_with_the_given_id_exists(): void
     {
-        /** @var SettingsRepository|MockInterface */
-        $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows([
-            'getFulfilledState' => 'wc-fulfilled',
-            'getOrderIdFieldName' => 'order_id'
-        ]);
+        self::$request
+            ->allows('get_body')
+            ->andReturn(json_encode(['orderId' => self::ORDER_ID]));
 
-        /** @var MockInterface|\WC_Order */
-        $order = Mockery::mock("WC_Order");
-        $order->allows("get_status");
-        $order->allows("update_meta_data");
-        $order->allows("save");
+        self::$settingsRepository
+            ->allows([
+                'getFulfilledState'   => 'wc-fulfilled',
+                'getOrderIdFieldName' => 'order_id'
+            ]);
 
-        /** @var MockInterface|OrderRepository */
-        $orderRepository = Mockery::mock(OrderRepository::class);
-        $orderRepository->allows([
-            "findById" => $order
-        ]);
+        self::$order
+            ->allows('get_status')
+            ->allows('update_meta_data')
+            ->allows('save');
 
-        /** @var \WP_REST_Request|MockInterface */
-        $request = Mockery::mock(\WP_REST_Request::class);
-        $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"orderId": 1234567890, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
+        self::$orderRepository
+            ->allows(['findById' => self::$order]);
 
-        $controller = new OrderController($settingsRepository, $orderRepository);
-
-        $controller->handleSuccessCallback($request);
-
-        $order->shouldHaveReceived("update_meta_data", ["order_id", 1234567890]);
-        $order->shouldHaveReceived("save");
+        $this->assertEquals(200, self::successCallback()->get_status());
     }
 
-    public function test_the_fulfillment_callback_updates_the_woocommerce_order_status()
+    public function test_the_success_callback_updates_the_meta_order_id()
     {
-        /** @var \WP_REST_Request|MockInterface */
-        $request = Mockery::mock(\WP_REST_Request::class);
-        $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"orderId": 1234567890, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
+        self::$request
+            ->allows('get_body')
+            ->andReturn(json_encode(['orderId' => self::NEW_ORDER_ID]));
 
-        /** @var SettingsRepository|MockInterface */
-        $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows([
-            'getFulfilledState' => 'wc-fulfilled',
-            'getTrackingLinkFieldName' => 'tracking_id',
-            'getCarrierInformationFieldName' => 'carrier_information'
-        ]);
+        self::$settingsRepository
+            ->allows([
+                'getFulfilledState'   => 'wc-fulfilled',
+                'getOrderIdFieldName' => 'order_id'
+            ]);
 
-        /** @var MockInterface|\WC_Order */
-        $order = Mockery::mock("WC_Order");
-        $order->allows("set_status");
-        $order->allows("get_status");
-        $order->allows("update_meta_data");
-        $order->allows("save");
+        self::$order
+            ->allows('get_status')
+            ->allows('update_meta_data')
+            ->allows('save');
 
-        /** @var MockInterface|OrderRepository */
-        $orderRepository = Mockery::mock(OrderRepository::class);
-        $orderRepository->allows([
-            "findById" => $order
-        ]);
+        self::$orderRepository
+            ->allows(['findById' => self::$order]);
 
-        $controller = new OrderController($settingsRepository, $orderRepository);
+        self::successCallback();
 
-        $controller->handleFulfillmentCallback($request);
-
-        $order->shouldHaveReceived("set_status", ["wc-fulfilled"]);
-        $order->shouldHaveReceived('save');
+        self::$order
+            ->shouldHaveReceived('update_meta_data', ['order_id', 1234567890])
+            ->shouldHaveReceived('save');
     }
 
-    public function test_the_fulfillment_callback_updates_the_order_meta_data()
+
+    public function test_the_fulfillment_callback_updates_the_woocommerce_order_status(): void
     {
-        /** @var \WP_REST_Request|MockInterface */
-        $request = Mockery::mock(\WP_REST_Request::class);
-        $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"orderId": 1234567890, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
+        self::$request
+            ->allows('get_body')
+            ->andReturn(
+                json_encode([
+                    'orderId'          => self::NEW_ORDER_ID,
+                    'trackingUrl'      => self::TRACKING_URL,
+                    'transportProduct' => self::TRANSPORT_PRODUCT
+                ])
+            );
 
-        /** @var SettingsRepository|MockInterface */
-        $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows([
-            'getFulfilledState' => 'wc-fulfilled',
-            'getTrackingLinkFieldName' => 'tracking_id',
-            'getCarrierInformationFieldName' => 'carrier_information'
-        ]);
+        self::$settingsRepository
+            ->allows([
+                'getFulfilledState'              => 'wc-fulfilled',
+                'getTrackingLinkFieldName'       => 'tracking_id',
+                'getCarrierInformationFieldName' => 'carrier_information'
+            ]);
 
-        /** @var MockInterface|\WC_Order */
-        $order = Mockery::mock("WC_Order");
-        $order->allows("set_status");
-        $order->allows("get_status");
-        $order->allows("update_meta_data");
-        $order->allows("save");
+        self::$order
+            ->allows('set_status')
+            ->allows('get_status')
+            ->allows('update_meta_data')
+            ->allows('save');
 
-        /** @var MockInterface|OrderRepository */
-        $orderRepository = Mockery::mock(OrderRepository::class);
-        $orderRepository->allows([
-            "findById" => $order
-        ]);
+        self::$orderRepository
+            ->allows(['findById' => self::$order]);
 
-        $controller = new OrderController($settingsRepository, $orderRepository);
+        self::fulfillmentCallback();
 
-        $controller->handleFulfillmentCallback($request);
-
-        $order->shouldHaveReceived("update_meta_data", ["tracking_id", "http://example.com"]);
-        $order->shouldHaveReceived("update_meta_data", ["carrier_information", "DHL"]);
+        self::$order
+            ->shouldHaveReceived('set_status', ['wc-fulfilled'])
+            ->shouldHaveReceived('save');
     }
 
-    public function test_the_fulfillment_callback_returns_200_on_success()
+    public function test_the_fulfillment_callback_updates_the_order_meta_data(): void
     {
-        /** @var \WP_REST_Request|MockInterface */
-        $request = Mockery::mock(\WP_REST_Request::class);
-        $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"orderId": 1234567890, "trackingUrl": "http://example.com", "transportProduct": "DHL"}');
+        self::$request
+            ->allows('get_body')
+            ->andReturn(
+                json_encode([
+                    'orderId'          => self::NEW_ORDER_ID,
+                    'trackingUrl'      => self::TRACKING_URL,
+                    'transportProduct' => self::TRANSPORT_PRODUCT
+                ])
+            );
 
-        /** @var SettingsRepository|MockInterface */
-        $settingsRepository = Mockery::mock(SettingsRepository::class);
-        $settingsRepository->allows([
-            'getFulfilledState' => 'wc-fulfilled',
-            'getTrackingLinkFieldName' => 'tracking_id',
-            'getCarrierInformationFieldName' => 'carrier_information'
-        ]);
+        self::$settingsRepository
+            ->allows([
+                'getFulfilledState'              => 'wc-fulfilled',
+                'getTrackingLinkFieldName'       => 'tracking_id',
+                'getCarrierInformationFieldName' => 'carrier_information'
+            ]);
 
-        /** @var MockInterface|\WC_Order */
-        $order = Mockery::mock("WC_Order");
-        $order->allows("set_status");
-        $order->allows("get_status");
-        $order->allows("update_meta_data");
-        $order->allows("save");
+        self::$order
+            ->allows('set_status')
+            ->allows('get_status')
+            ->allows('update_meta_data')
+            ->allows('save');
 
-        /** @var MockInterface|OrderRepository */
-        $orderRepository = Mockery::mock(OrderRepository::class);
-        $orderRepository->allows([
-            "findById" => $order
-        ]);
+        self::$orderRepository
+            ->allows(['findById' => self::$order]);
 
-        $controller = new OrderController($settingsRepository, $orderRepository);
+        self::fulfillmentCallback();
 
-        $response = $controller->handleFulfillmentCallback($request);
-
-        $this->assertEquals(200, $response->get_status());
+        self::$order
+            ->shouldHaveReceived('update_meta_data', ['tracking_id', 'http://example.com'])
+            ->shouldHaveReceived('update_meta_data', ['carrier_information', 'DHL']);
     }
 
-    public function test_the_fulfillment_callback_returns_404_if_the_order_cannot_be_found()
+
+    public function test_the_fulfillment_callback_does_not_create_tracking_url_meta_if_empty_string_is_in_request(): void
     {
-        /** @var \WP_REST_Request|MockInterface */
-        $request = Mockery::mock(\WP_REST_Request::class);
-        $request->allows('get_params')->andReturn(['id' => 12]);
-        $request->allows('get_body')->andReturn('{"order_id": 12, "tracking_url": "http://example.com", "transport_product": "DHL"}');
+        self::$request
+            ->allows('get_body')
+            ->andReturn(
+                json_encode([
+                    'orderId'          => self::NEW_ORDER_ID,
+                    'trackingUrl'      => '',
+                    'transportProduct' => self::TRANSPORT_PRODUCT
+                ])
+            );
 
-        /** @var SettingsRepository|MockInterface */
-        $settingsRepository = Mockery::mock(SettingsRepository::class);
+        self::$settingsRepository
+            ->allows([
+                'getFulfilledState'              => 'wc-fulfilled',
+                'getTrackingLinkFieldName'       => 'tracking_id',
+                'getCarrierInformationFieldName' => 'carrier_information'
+            ]);
 
-        /** @var MockInterface|OrderRepository */
-        $orderRepository = Mockery::mock(OrderRepository::class);
-        $orderRepository->allows([
-            "findById" => null
-        ]);
+        self::$order
+            ->allows('set_status')
+            ->allows('get_status')
+            ->allows('update_meta_data')
+            ->allows('save');
 
-        $controller = new OrderController($settingsRepository, $orderRepository);
+        self::$orderRepository
+            ->allows(['findById' => self::$order]);
 
-        $response = $controller->handleFulfillmentCallback($request);
+        self::fulfillmentCallback();
 
-        $this->assertEquals(404, $response->get_status());
+        self::$order
+            ->shouldNotHaveReceived('update_meta_data', ['tracking_id', ''])
+            ->shouldHaveReceived('update_meta_data', ['carrier_information', 'DHL']);
+    }
+
+
+    public function test_the_fulfillment_callback_returns_200_on_success(): void
+    {
+        self::$request
+            ->allows('get_body')
+            ->andReturn(
+                json_encode([
+                    'orderId'          => self::NEW_ORDER_ID,
+                    'trackingUrl'      => self::TRACKING_URL,
+                    'transportProduct' => self::TRANSPORT_PRODUCT
+                ])
+            );
+
+        self::$settingsRepository
+            ->allows([
+                'getFulfilledState'              => 'wc-fulfilled',
+                'getTrackingLinkFieldName'       => 'tracking_id',
+                'getCarrierInformationFieldName' => 'carrier_information'
+            ]);
+
+        self::$order
+            ->allows('set_status')
+            ->allows('get_status')
+            ->allows('update_meta_data')
+            ->allows('save');
+
+        self::$orderRepository
+            ->allows(['findById' => self::$order]);
+
+        $this->assertEquals(200, self::fulfillmentCallback()->get_status());
+    }
+
+
+    public function test_the_fulfillment_callback_returns_404_if_the_order_cannot_be_found(): void
+    {
+        self::$request
+            ->allows('get_body')
+            ->andReturn(
+                json_encode([
+                    'orderId'          => self::ORDER_ID,
+                    'trackingUrl'      => self::TRACKING_URL,
+                    'transportProduct' => self::TRANSPORT_PRODUCT
+                ])
+            );
+
+        self::$orderRepository
+            ->allows(['findById' => null]);
+
+        $this->assertEquals(404, self::fulfillmentCallback()->get_status());
+    }
+
+
+    private static function fulfillmentCallback(): WP_REST_Response
+    {
+        return self::$orderController->handleFulfillmentCallback(self::$request);
+    }
+
+
+    private static function successCallback(): WP_REST_Response
+    {
+        return self::$orderController->handleSuccessCallback(self::$request);
     }
 }


### PR DESCRIPTION
Had some issues with the tests now they all run just fine.
And also some bugfixes:
  - on my machine `$db->base_prefix` and `$db->prefix` are not the same for some reason.
  - the timezones where different in php and sql (on my machine), now i don't rely on mysql dates but on php timezone.
  - the where statement in the failed_request_repository had an error (but the test didn't catch it if u ran the test before 21:05 : ) 