### PR TITLE
docs: move mock api instructions to confluence

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -31,7 +31,7 @@ For VSCode users there is also one more caveat with `intelephense` the stubs for
 
 ### Mock APIs
 
-How to mock the API can be found here  [Towa internal confluence link](https://towa-digital.atlassian.net/wiki/spaces/GWAC/pages/450592804/Development) (link only available for TOWA team members)
+Information about the TOWA-internal Mock API can be found here [Towa internal confluence link](https://towa-digital.atlassian.net/wiki/spaces/GWAC/pages/450592804/Development) (link only available for TOWA team members)
 
 ## Sandbox API
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,9 +31,7 @@ For VSCode users there is also one more caveat with `intelephense` the stubs for
 
 ### Mock APIs
 
-To be able to work with API data without relying on the Gebrüder Weiss APIs, there are two mock APIs:
-- https://oauth.gebrueder-weiss-woocommerce.towa-online.at: Provides a mock OAuth Server that creates a token for any provided credentials. [Repo](https://bitbucket.org/towa_gmbh/gebrueder-weiss-oauth-mock/src/main/)
-- https://api.gebrueder-weiss-woocommerce.towa-online.at: Mock API for the actual API, it returns dummy data based on the examples defined in the Gebrüder Weiss API Schema. [Repo](https://bitbucket.org/towa_gmbh/gebrueder-weiss-api-mock/src/main/)
+How to mock the API can be found here  [Towa internal confluence link](https://towa-digital.atlassian.net/wiki/spaces/GWAC/pages/450592804/Development) (link only available for TOWA team members)
 
 ## Sandbox API
 


### PR DESCRIPTION
# TL;DR

- move documentation about mocking to confluence